### PR TITLE
Adding a test that includes a diamond cycle, attached and detached from the visible root.

### DIFF
--- a/test/reachable-test.js
+++ b/test/reachable-test.js
@@ -3,6 +3,15 @@ import tape from "tape-await";
 import {runtime as createRuntime} from "../";
 import "./requestAnimationFrame";
 
+async function isCircular(variable) {
+  try {
+    await variable._value;
+    return false;
+  } catch (err) {
+    return err.message === "circular definition";
+  }
+}
+
 tape("variable.define recomputes reachability as expected", async test => {
   const document = new JSDOM(`<div id=foo></div>`).window.document;
   const runtime = createRuntime();
@@ -65,30 +74,44 @@ tape("variable.define does not terminate reachable generators", async test => {
 });
 
 tape("variable.define correctly detects reachability for unreachable cycles", async test => {
+  let returned = false;
   const document = new JSDOM(`<div id=foo></div>`).window.document;
   const runtime = createRuntime();
   const module = runtime.module();
   const bar = module.variable().define("bar", ["baz"], baz => `bar-${baz}`);
   const baz = module.variable().define("baz", ["quux"], quux => `baz-${quux}`);
-  const quux = module.variable().define("quux", ["zapp"], zapp => `quux-${zapp}`);
+  const quux = module.variable().define("quux", ["zapp"], function* (zapp) { try { while (true) yield `quux-${zapp}`; } finally { returned = true; }});
   const zapp = module.variable().define("zapp", ["bar"], bar => `zaap-${bar}`);
   await new Promise(setImmediate);
   test.equal(bar._reachable, false);
+  test.equal(await isCircular(bar), true);
   test.equal(baz._reachable, false);
+  test.equal(await isCircular(baz), true);
   test.equal(quux._reachable, false);
+  test.equal(await isCircular(quux), true);
+  test.equal(!!quux._generator, false);
+  test.equal(returned, false);
   test.equal(zapp._reachable, false);
+  test.equal(await isCircular(zapp), true);
   const foo = module.variable(document.querySelector("#foo")).define("foo", ["bar"], bar => bar);
   await new Promise(setImmediate);
   test.equal(foo._reachable, true);
+  test.equal(await isCircular(foo), true); // Variables that depend on cycles are themselves circular.
   test.equal(bar._reachable, true);
   test.equal(baz._reachable, true);
   test.equal(quux._reachable, true);
+  test.equal(!quux._generator, true); // Generator is never run in a circular definition.
+  test.equal(returned, false);
   test.equal(zapp._reachable, true);
   foo.define("foo", "foo");
   await new Promise(setImmediate);
   test.equal(foo._reachable, true);
+  test.equal(await isCircular(foo), false);
   test.equal(bar._reachable, false);
+  test.equal(await isCircular(bar), true);
   test.equal(baz._reachable, false);
   test.equal(quux._reachable, false);
+  test.equal(quux._generator, undefined);
+  test.equal(returned, false); // Generator is never finalized because it has never run.
   test.equal(zapp._reachable, false);
 });


### PR DESCRIPTION
Asserts that reachability and circularity are detected correctly for cycles in variables.