### PR TITLE
Only highlight explicit languages

### DIFF
--- a/src/stdlib/md.js
+++ b/src/stdlib/md.js
@@ -5,7 +5,7 @@ export default function(require) {
         var string = strings[0] + "", i = 0, n = arguments.length;
         while (++i < n) string += arguments[i] + "" + strings[i];
         var root = document.createElement("div");
-        root.innerHTML = marked(string, { langPrefix: '' }).trim();
+        root.innerHTML = marked(string, {langPrefix: ""}).trim();
         var code = root.querySelectorAll("pre code[class]");
         if (code.length > 0) require("/highlight.js").then(function(hl) { code.forEach(hl.highlightBlock); });
         return root.childNodes.length === 1 ? root.removeChild(root.firstChild) : root;


### PR DESCRIPTION
Does so by:

- Only searching for code elements with class
- Changing the langPrefix in marked to be '', so that its classes work
  for highlight.js's detection.

Fixes #42