### PR TITLE
Don’t yield when initially undefined.

### DIFF
--- a/src/stdlib/generators/input.js
+++ b/src/stdlib/generators/input.js
@@ -2,8 +2,10 @@ import observe from "./observe";
 
 export default function(input) {
   return observe(function(change) {
-    var event = eventof(input), inputted = function() { change(valueof(input)); };
-    input.addEventListener(event, inputted), inputted();
+    var event = eventof(input), value = valueof(input);
+    function inputted() { change(valueof(input)); }
+    input.addEventListener(event, inputted);
+    if (value !== undefined) change(value);
     return function() { input.removeEventListener(event, inputted); };
   });
 }


### PR DESCRIPTION
Fixes #32. If the value of the element passed to Generators.input is initially undefined, don’t immediately yield this value; instead, wait for the element to emit its first input event.