### PR TITLE
[wip] Add dynamic import. Fixes #47.

### DIFF
--- a/src/stdlib/import.js
+++ b/src/stdlib/import.js
@@ -1,0 +1,22 @@
+var id = 0;
+
+function url(name) {
+  if (/^(\w+:)?\/\//i.test(name) || /^[.]{0,2}\//i.test(name)) return name;
+  if (!name.length || /^[\s._]/.test(name) || /\s$/.test(name)) throw new Error("illegal name");
+  return "https://unpkg.com/" + name + "?module";
+}
+
+export default function(name) {
+  return new Promise(function(resolve) {
+    var global = "__runtime_import_" + ++id;
+    window[global] = function(module) {
+      resolve(module);
+      delete window[global];
+      script.remove();
+    };
+    var script = document.createElement("script");
+    script.type = "module";
+    script.textContent = "import * as m from \"" + url(name) + "\"; window." + global + "(m);";
+    document.head.appendChild(script);
+  });
+}

--- a/src/stdlib/index.js
+++ b/src/stdlib/index.js
@@ -4,6 +4,7 @@ import DOM from "./dom/index";
 import Files from "./files/index";
 import Generators from "./generators/index";
 import html from "./html";
+import importer from "./import";
 import md from "./md";
 import now from "./now";
 import Promises from "./promises/index";
@@ -18,6 +19,7 @@ export default function(resolve) {
     Files: Files,
     Generators: Generators,
     Promises: Promises,
+    import: constant(importer),
     require: constant(require),
     html: html,
     md: md(require, resolve),


### PR DESCRIPTION
It works! TODO:

- [ ] Change the UI parser to allow dynamic import statements, but remap them to calls to this builtin.
- [ ] Alternatively, don’t implement this as a builtin, and instead just rely on the browser’s native support for dynamic imports. However, should we still have the parser resolve names to URLs automatically?