### PR TITLE
Changes to notebook-runtime for highlighting of runtime triggered errors

### DIFF
--- a/src/variable.js
+++ b/src/variable.js
@@ -56,7 +56,7 @@ function variable_rejector(variable) {
     } else {
       error = new ResolutionError(variable._name + " could not be resolved", variable._name);
     }
-    error.inputName = variable._name;
+    error.variable = {input: variable._name};
     throw error;
   };
 }
@@ -64,7 +64,7 @@ function variable_rejector(variable) {
 function variable_duplicate(name) {
   return function() {
     const error = new ReferenceError(name + " is defined more than once");
-    error.inputName = name;
+    error.variable = {name};
     throw error;
   };
 }


### PR DESCRIPTION
Although the corresponding "notebook" patch isn't quite ready to review yet — this is the change I'd like to make to the notebook-runtime.

For cell inputs that can't be resolved, or are duplicated, or can't be found — we attach the name of the cell input to the thrown error, for later lookup in the cell's inputs' locations in the notebook.