### PR TITLE
Remove require.at.

### DIFF
--- a/README.md
+++ b/README.md
@@ -558,17 +558,15 @@ require("d3-array", "d3-color").then(d3 => {
 });
 ```
 
-See [d3-require](https://github.com/d3/d3-require) for more information.
-
-<a href="#require_at" name="require_at">#</a> require.<b>at</b>(<i>versions</i>)
-
-Returns a [require](#require) function where each module in the specified *versions* object has the corresponding semver range or tag. For example, to load [d3-array](https://github.com/d3/d3-array) 1.1.x:
+Or, to load [d3-array](https://github.com/d3/d3-array) 1.1.x:
 
 ```js
-require.at({"d3-array": "1.1"})("d3-array").then(d3 => {
+require("d3-array@1.1").then(d3 => {
   console.log(d3.range(100));
 });
 ```
+
+See [d3-require](https://github.com/d3/d3-require) for more information.
 
 <a href="#resolve" name="resolve">#</a> <b>resolve</b>(<i>name</i>)
 

--- a/src/stdlib/index.js
+++ b/src/stdlib/index.js
@@ -13,7 +13,6 @@ import width from "./width";
 export default function(resolve) {
   if (resolve == null) resolve = resolveDefault;
   var require = requireFrom(resolve);
-  require.at = requireAt(resolve);
   return {
     DOM: DOM,
     Files: Files,
@@ -26,13 +25,5 @@ export default function(resolve) {
     tex: tex(require, resolve),
     now: now,
     width: width
-  };
-}
-
-function requireAt(resolve) {
-  return function(versions) {
-    return requireFrom(function(name) {
-      return resolve(name in versions ? name + "@" + versions[name] : name);
-    });
   };
 }


### PR DESCRIPTION
Not sure we actually want to support this (*e.g.*, if we decide that `require` should read the package.json internally), so safer to remove it for now.