### PR TITLE
Fix versioning.

### DIFF
--- a/src/runtime.js
+++ b/src/runtime.js
@@ -113,12 +113,8 @@ function variable_value(variable) {
   return variable._value.catch(variable._rejector);
 }
 
-function variable_version(version, variable) {
-  return Math.max(variable._version, version);
-}
-
 function variable_compute(variable) {
-  var version = variable._version = variable._inputs.reduce(variable_version, variable._version);
+  var version = ++variable._version;
   if (variable._generator) {
     variable._generator.return();
     variable._generator = null;

--- a/src/variable.js
+++ b/src/variable.js
@@ -159,7 +159,6 @@ function variable_defineImpl(name, inputs, definition) {
     this._name = name;
   }
 
-  ++this._version;
   runtime._updates.add(this);
   runtime._compute();
   return this;


### PR DESCRIPTION
The version needs to increment whenever a variable is recomputed, not just when a variable is redefined. That’s because a variable’s value is invalidated whenever its definition OR its input values change.