### PR TITLE
Stricter encoding of inspected strings.

### DIFF
--- a/src/inspect/formatString.js
+++ b/src/inspect/formatString.js
@@ -1,0 +1,24 @@
+/* eslint-disable no-control-regex */
+
+export default function formatString(string, full) {
+  if (full) return (count(string, /["\n]/g) <= count(string, /`|\${/g) ? JSON.stringify : templatify)(string);
+  if (string.length > 100) string = `${string.slice(0, 50)}…${string.slice(-49)}`;
+  return JSON.stringify(string);
+}
+
+function templatify(string) {
+  return "`" + string.replace(/[\\`\x00-\x09\x0b-\x19]|\${/g, templatifyChar) + "`";
+}
+
+function templatifyChar(char) {
+  var code = char.charCodeAt(0);
+  return code < 0x10 ? "\\x0" + code.toString(16)
+      : code < 0x20 ? "\\x" + code.toString(16)
+      : "\\" + char;
+}
+
+function count(string, re) {
+  var n = 0;
+  while (re.exec(string)) ++n;
+  return n;
+}

--- a/src/inspect/index.js
+++ b/src/inspect/index.js
@@ -4,6 +4,7 @@ import inspectExpanded from "./expanded";
 import formatDate from "./formatDate";
 import formatError from "./formatError";
 import formatRegExp from "./formatRegExp";
+import formatString from "./formatString";
 import formatSymbol from "./formatSymbol";
 import inspectFunction from "./inspectFunction";
 
@@ -12,8 +13,13 @@ var objectToString = Object.prototype.toString;
 export default function inspect(value, shallow, expand) {
   var type = typeof value;
   switch (type) {
+    case "boolean":
+    case "number":
+    case "undefined": { value += ""; break; }
+    case "string": { value = formatString(value, shallow === false); break; }
+    case "symbol": { value = formatSymbol(value); break; }
     case "function": { return inspectFunction(value); }
-    case "object": {
+    default: {
       if (value === null) { type = null, value = "null"; break; }
       if (value instanceof Date) { type = "date", value = formatDate(value); break; }
       switch (objectToString.call(value)) { // TODO Symbol.toStringTag?
@@ -22,12 +28,6 @@ export default function inspect(value, shallow, expand) {
         case "[object DOMException]": { type = "error", value = formatError(value); break; }
         default: return (expand ? inspectExpanded : inspectCollapsed)(value, shallow);
       }
-      break;
-    }
-    case "symbol": { value = formatSymbol(value); break; }
-    default: {
-      value += "";
-      if (shallow && !expand && value.length > 100) value = `${value.slice(0, 50)}…${value.slice(-49)}`;
       break;
     }
   }


### PR DESCRIPTION
Rather than try to display the raw string value as-is, the inspector presents string values as they would be written in JavaScript. This allows you to copy-and-paste a string value from the inspector into JavaScript without needing to escape special characters by hand.

To improve the readability of strings with newlines, in the special case that a string is being inspected directly (rather than as a descendant of some object), we check whether the string requires less escaping as a template literal, and if so, present it as such.

Fixes observablehq/notebook#594.