### PR TITLE
Revert changes to display DocumentFragment.

### DIFF
--- a/src/runtime.js
+++ b/src/runtime.js
@@ -211,18 +211,20 @@ function variable_displayError(variable, error) {
 function variable_displayValue(variable, value) {
   var node = variable._node;
   if (!node) return;
-  if (!(value instanceof Node) || (value.parentNode && !node.contains(value))) {
+  if (!(value instanceof Element || value instanceof Text) || (value.parentNode && value.parentNode !== node)) {
     value = inspect(value, false, node.firstChild // TODO Do this better.
         && node.firstChild.classList
         && node.firstChild.classList.contains("O--expanded"));
     value.classList.add("O--inspect");
   }
-  if (node.firstChild) {
-    while (node.lastChild !== node.firstChild) node.removeChild(node.lastChild);
-    if (node.firstChild !== value) node.replaceChild(value, node.firstChild);
-  } else {
-    node.appendChild(value);
-  }
   node.className = "O";
+  if (node.firstChild !== value) {
+    if (node.firstChild) {
+      while (node.lastChild !== node.firstChild) node.removeChild(node.lastChild);
+      node.replaceChild(value, node.firstChild);
+    } else {
+      node.appendChild(value);
+    }
+  }
   dispatch(node, "update");
 }


### PR DESCRIPTION
This restores the old behavior: we only display Element and Text nodes. Displaying document fragments is bad because it empties them.