### PR TITLE
Avoid crashing on getters and blocked property access

### DIFF
--- a/src/inspect/collapsed.js
+++ b/src/inspect/collapsed.js
@@ -4,6 +4,7 @@ import isArrayIndex from "./isArrayIndex";
 import isArrayLike from "./isArrayLike";
 import getKeysAndSymbols from "./getKeysAndSymbols";
 import formatSymbol from "./formatSymbol";
+import {maybeProperty} from "./forbidden";
 
 export default function inspectCollapsed(object, shallow) {
   var span = document.createElement("span"),
@@ -60,7 +61,7 @@ export default function inspectCollapsed(object, shallow) {
         }
         span.appendChild(document.createTextNode(": "));
       }
-      span.appendChild(inspect(object[key], true));
+      span.appendChild(inspect(maybeProperty(object, key), true));
     }
   }
 

--- a/src/inspect/expanded.js
+++ b/src/inspect/expanded.js
@@ -5,6 +5,7 @@ import getKeysAndSymbols from "./getKeysAndSymbols";
 import inspect, {replace} from "./index";
 import isArrayIndex from "./isArrayIndex";
 import isArrayLike from "./isArrayLike";
+import {maybeProperty} from "./forbidden";
 
 export default function inspectExpanded(object) {
   var span = document.createElement("span"),
@@ -100,7 +101,7 @@ function* objectFields(object) {
       span.textContent = `  ${key}`;
     }
     item.appendChild(document.createTextNode(": "));
-    item.appendChild(inspect(object[key]));
+    item.appendChild(inspect(maybeProperty(object, key)));
     yield item;
   }
 }

--- a/src/inspect/forbidden.js
+++ b/src/inspect/forbidden.js
@@ -1,0 +1,10 @@
+export function maybeProperty(object, key) {
+  try {
+    object[key] && object[key].constructor;
+  } catch (e) {
+    return FORBIDDEN;
+  }
+  return object[key];
+}
+
+export const FORBIDDEN = {};

--- a/src/inspect/index.js
+++ b/src/inspect/index.js
@@ -7,6 +7,7 @@ import formatRegExp from "./formatRegExp";
 import formatString from "./formatString";
 import formatSymbol from "./formatSymbol";
 import inspectFunction from "./inspectFunction";
+import {FORBIDDEN} from "./forbidden";
 
 var objectToString = Object.prototype.toString;
 
@@ -22,6 +23,7 @@ export default function inspect(value, shallow, expand) {
     default: {
       if (value === null) { type = null, value = "null"; break; }
       if (value instanceof Date) { type = "date", value = formatDate(value); break; }
+      if (value === FORBIDDEN) { type = "forbidden", value = "[forbidden]"; break; }
       switch (objectToString.call(value)) { // TODO Symbol.toStringTag?
         case "[object RegExp]": { type = "regexp", value = formatRegExp(value); break; }
         case "[object Error]": // https://github.com/lodash/lodash/blob/master/isError.js#L26


### PR DESCRIPTION
Fixes #62 

userland-devtoolsformatters is slicker and cool but not ready for primetime; in the meantime, this fixes the crashes around window.parent and other forbidden properties, ~and also shows getters as [getter]. If this seems chill, it'll require a bump of notebook to bring in the functionality and one new class to make the `[getter]` text a grayish color.~