### PR TITLE
Relax regex to allow inspection of complex function args

### DIFF
--- a/src/inspect/inspectFunction.js
+++ b/src/inspect/inspectFunction.js
@@ -18,21 +18,21 @@ export default function inspectFunction(f) {
   // A class, possibly named.
   // class Name
   if (type === TYPE_CLASS) {
-    return formatFunction(type, f.name || "");
+    return formatFunction(type, f.name);
   }
 
   // An arrow function with a single argument.
   // foo =>
   // async foo =>
   if (m = /^(?:async\s*)?(\w+)\s*=>/.exec(t)) {
-    return formatFunction(type, "(" + m[1] + ")");
+    return formatFunction(type, null, m[1]);
   }
 
   // An arrow function with parenthesized arguments.
   // (…)
   // async (…)
   if (m = /^(?:async\s*)?\((.*)\)/.exec(t)) {
-    return formatFunction(type, m[1] ? "(" + m[1].replace(/\s*,\s*/g, ", ") + ")" : "()");
+    return formatFunction(type, null, m[1] && trim(m[1].replace(/\s*,\s*/g, ", ")));
   }
 
   // A function, possibly: async, generator, anonymous, simply arguments.
@@ -41,19 +41,19 @@ export default function inspectFunction(f) {
   // async function name(…)
   // async function* name(…)
   if (m = /^(?:async\s*)?function(?:\s*\*)?(?:\s*\w+)?\s*\((.*)\)/.exec(t)) {
-    return formatFunction(type, (f.name || "") + (m[1] ? "(" + m[1].replace(/\s*,\s*/g, ", ") + ")" : "()"));
+    return formatFunction(type, f.name, m[1] && trim(m[1].replace(/\s*,\s*/g, ", ")));
   }
 
   // Something else, like destructuring, comments or default values.
-  return formatFunction(type, (f.name || "") + "(…)");
+  return formatFunction(type, f.name, "…");
 }
 
-function formatFunction(type, name) {
-  var span = document.createElement("span");
-  span.className = "O--function";
-  var spanType = span.appendChild(document.createElement("span"));
-  spanType.className = "O--keyword";
-  spanType.textContent = type.prefix;
-  span.appendChild(document.createTextNode(" " + name));
-  return span;
+function trim(string) {
+  return string.length > 60 ? string.substr(0, 60) + "…" : string;
+}
+
+function formatFunction(type, name, args) {
+  var template = document.createElement("template");
+  template.innerHTML = `<span class="O--function"><span class="O--keyword">${type.prefix}</span> ${name || ""}(<span class="O--gray">${args || ""}</span>)</span>`;
+  return template.content.firstChild;
 }


### PR DESCRIPTION
Per Kelley's request here:

https://talk.observablehq.com/t/optional-function-arguments-cell-annotations/509

It's not perfect — that would require a real parse — but if we relax our inspector's regex for what it allows between function argument parentheses, it allows us to inspect default arguments, destructuring, and so on...

Currently:

![image](https://user-images.githubusercontent.com/4732/37535329-a041b632-2904-11e8-8900-8bf9f6de2311.png)

After:

![image](https://user-images.githubusercontent.com/4732/37535342-a8801262-2904-11e8-90a5-f329c587fc50.png)
