### PR TITLE
Remove d3-time-format dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,8 +17,7 @@
   },
   "dependencies": {
     "esm": "^3.0.5",
-    "@observablehq/notebook-stdlib": "https://github.com/observablehq/notebook-stdlib#38f091d",
-    "d3-time-format": "^2.1.1"
+    "@observablehq/notebook-stdlib": "https://github.com/observablehq/notebook-stdlib#38f091d"
   },
   "devDependencies": {
     "eslint": "^4.12.1",

--- a/src/inspect/formatDate.js
+++ b/src/inspect/formatDate.js
@@ -1,14 +1,24 @@
-import {timeFormat} from "d3-time-format";
-
-var formatDay = timeFormat("%Y-%m-%d"),
-    formatMinute = timeFormat("%Y-%m-%dT%H:%M"),
-    formatSecond = timeFormat("%Y-%m-%dT%H:%M:%S"),
-    formatMillisecond = timeFormat("%Y-%m-%dT%H:%M:%S.%L");
+function pad(value, width) {
+  var s = value + "", length = s.length;
+  return length < width ? new Array(width - length + 1).join(0) + s : s;
+}
 
 export default function formatDate(date) {
-  return isNaN(date) ? "Invalid Date"
-      : (date.getMilliseconds() ? formatMillisecond
-          : date.getSeconds() ? formatSecond
-          : date.getMinutes() || date.getHours() ? formatMinute
-          : formatDay)(date);
+  if (isNaN(date)) return "Invalid Date";
+  return pad(date.getFullYear(), 4) + "-"
+      + pad(date.getMonth() + 1, 2) + "-"
+      + pad(date.getDate(), 2)
+      + (date.getMilliseconds() ? "T"
+          + pad(date.getHours(), 2) + ":"
+          + pad(date.getMinutes(), 2) + ":"
+          + pad(date.getSeconds(), 2) + "."
+          + pad(date.getMilliseconds(), 4)
+        : date.getSeconds() ? "T"
+          + pad(date.getHours(), 2) + ":"
+          + pad(date.getMinutes(), 2) + ":"
+          + pad(date.getSeconds(), 2)
+        : date.getMinutes() || date.getHours() ? "T"
+          + pad(date.getHours(), 2) + ":"
+          + pad(date.getMinutes(), 2)
+        : "");
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -289,16 +289,6 @@ d3-require@^0.6.6:
   version "0.6.6"
   resolved "https://registry.yarnpkg.com/d3-require/-/d3-require-0.6.6.tgz#cb01119b13d85c81aec97b2f88051731e89bf469"
 
-d3-time-format@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/d3-time-format/-/d3-time-format-2.1.1.tgz#85b7cdfbc9ffca187f14d3c456ffda268081bb31"
-  dependencies:
-    d3-time "1"
-
-d3-time@1:
-  version "1.0.8"
-  resolved "https://registry.yarnpkg.com/d3-time/-/d3-time-1.0.8.tgz#dbd2d6007bf416fe67a76d17947b784bffea1e84"
-
 dashdash@^1.12.0:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/dashdash/-/dashdash-1.14.1.tgz#853cfa0f7cbe2fed5de20326b8dd581035f6e2f0"


### PR DESCRIPTION
This reduces the size of notebook-runtime.js from 80KB to 56KB (unminified).