### PR TITLE
Remove stdlib; move to Runtime.load.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,22 +4,21 @@
 
 This library implements the reactive runtime for Observable notebooks. It lets you publish your interactive notebooks wherever you want: on your website, integrated into your web application or interactive dashboard — to any distant shore the web platform reaches. You can also use this library to author reactive programs by hand, to build new reactive editors, or simply to better understand how the Observable runtime works.
 
-## API Reference: High Level
+## API Reference
 
-### load()
+### Runtime
 
-<a href="#load" name="load">#</a> <b>load</b>(<i>notebook, nodes</i>)
+<a href="#Runtime_load" name="Runtime_load">#</a> Runtime.<b>load</b>(<i>builtins</i>, <i>notebook</i>[, <i>nodes</i>])
 
-The `load` function provides a convenient interface for wiring up an entire reactive notebook and attaching specific live variables to DOM nodes. Pass it a notebook specification, and an object mapping variable names to DOM nodes, and watch it go.
+Returns a new *runtime* for the given *builtins* object and *notebook* definition, possibly attaching variables in the main module to DOM elements in the specified *nodes*.  Each property on the *builtins* object defines a builtin variable for the runtime; these builtins are available as named inputs to any [defined variables](#variable_define) on any [module](#modules) associated with this runtime.
 
-The notebook specification is a JavaScript object, and may be downloaded as an ES module for any published notebook on [beta.observablehq.com](https://beta.observablehq.com). It looks like this:
+The *notebook* is an object with *notebook*.id and *notebook*.modules properties, such as:
 
 ```js
-const helloWorldNotebook = {
-  id: "hello-world@17",
-  runtimeVersion: 1,
+const notebook = {
+  id: "7d0eb6673a55a7c@3",
   modules: [{
-    id: "hello-world@17",
+    id: "7d0eb6673a55a7c@3",
     variables: [
       {
         name: "title",
@@ -32,31 +31,29 @@ const helloWorldNotebook = {
 }
 ```
 
-The notebook object may contain multiple modules, which may import variables between them. For example:
+The *notebook* may contain multiple modules as when the main module contains imports. For example:
 
 ```js
-const importNotebook = {
-  id: "importing@30",
-  runtimeVersion: 1,
+const notebook = {
+  id: "2710b07ba2cc1a8a@5",
   modules: [
     {
-      id: "importing@30",
+      id: "2710b07ba2cc1a8a@5",
       variables: [
         {
-          name: "viewof slider",
-          from: "@mbostock/simple-input-slider",
-          remote: "viewof input"
+          from: "904bc713463f843@7",
+          name: "foo",
+          remote: "foo"
         }
       ]
     {
-      id: "@mbostock/simple-input-slider",
+      id: "904bc713463f843@7",
       variables: [
         {
-          name: "input",
-          inputs: ["DOM"],
-          view: true,
-          value: function(DOM) {
-            return DOM.range(0, 100);
+          name: "foo",
+          inputs: [],
+          value: function() {
+            return 42;
           }
         }
       ]
@@ -65,23 +62,17 @@ const importNotebook = {
 };
 ```
 
-The *nodes* argument to load is an object that maps from main module variable names to DOM nodes, or to query selector strings which can look up DOM nodes. Variables in the notebook which aren't associated with a DOM node (or aren't indirectly depended on by any variable that is associated with a DOM node),  will not be evaluated.
+The *nodes* object that maps from variable names in the main module to DOM elements or DOM element selectors. Variables in the notebook which are not associated with a DOM node (or aren’t indirectly depended on by any variable that is associated with a DOM node), will not be evaluated.
 
 ```js
-const nodes = {"viewof slider", "#article .slider"};
-
-// And finally:
-
-load(importNotebook, nodes);
+Runtime.load(notebook, {
+  "foo": "#foo"
+});
 ```
-
-## API Reference: Low Level
-
-### Runtime
 
 <a href="#runtime" name="runtime">#</a> new <b>Runtime</b>(<i>builtins</i>)
 
-Returns a new [runtime](#runtimes). Each property on the *builtins* object defines a builtin for the runtime; these builtins are available as named inputs to any [defined variables](#variable_define) on any [module](#modules) associated with this runtime.
+Returns a new [runtime](#runtimes). Each property on the *builtins* object defines a builtin variable for the runtime; these builtins are available as named inputs to any [defined variables](#variable_define) on any [module](#modules) associated with this runtime.
 
 For example, to create a runtime whose only builtin is `color`:
 

--- a/package.json
+++ b/package.json
@@ -16,8 +16,7 @@
     "cjs": true
   },
   "dependencies": {
-    "esm": "^3.0.5",
-    "@observablehq/notebook-stdlib": "https://github.com/observablehq/notebook-stdlib#fb27975"
+    "esm": "^3.0.5"
   },
   "devDependencies": {
     "eslint": "^4.12.1",

--- a/src/index.js
+++ b/src/index.js
@@ -1,35 +1,4 @@
-import {Library} from "@observablehq/notebook-stdlib";
 import {RuntimeError} from "./errors";
-import {default as Runtime} from "./runtime";
+import Runtime from "./runtime";
 
-export {Library, Runtime, RuntimeError};
-
-export function load(notebook, nodes = {}) {
-  const {modules} = notebook;
-  const library = new Library();
-  const runtime = new Runtime(library);
-  const moduleMap = new Map();
-
-  modules.forEach(m =>  moduleMap.set(m.id, runtime.module()));
-
-  modules.forEach(m => {
-    const module = moduleMap.get(m.id);
-
-    function module_variable(name) {
-      let node = m.id === notebook.id ? nodes[name] : null;
-      if (typeof node === "string") node = document.querySelector(node);
-      return module.variable(node);
-    }
-
-    m.variables.forEach(v => {
-      const variable = module_variable(v.name);
-      if (v.from) {
-        const importedModule = moduleMap.get(v.from);
-        if (!importedModule) throw new RuntimeError(`unable to load module "${v.from}"`);
-        variable.import(v.name, v.remote, importedModule);
-      } else {
-        variable.define(v.name, v.inputs, v.value);
-      }
-    });
-  });
-}
+export {Runtime, RuntimeError};

--- a/src/load.js
+++ b/src/load.js
@@ -1,0 +1,26 @@
+import Runtime from "./runtime";
+
+export default function load(library, {modules, id}, nodes = {}) {
+  const map = new Map;
+  const runtime = new Runtime(library);
+  const main = runtime_module(id);
+
+  function runtime_module(id) {
+    let module = map.get(id);
+    if (!module) map.set(id, module = runtime.module());
+    return module;
+  }
+
+  for (const m of modules) {
+    const module = runtime_module(m.id);
+    for (const v of m.variables) {
+      let node = module === main ? nodes[v.name] : null;
+      if (typeof node === "string") node = document.querySelector(node);
+      const variable = module.variable(node);
+      if (v.from) variable.import(v.name, v.remote, runtime_module(v.from));
+      else variable.define(v.name, v.inputs, v.value);
+    }
+  }
+
+  return runtime;
+}

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -2,6 +2,7 @@ import dispatch from "./dispatch";
 import inspect from "./inspect/index";
 import {RuntimeError} from "./errors";
 import generatorish from "./generatorish";
+import load from "./load";
 import Module from "./module";
 import noop from "./noop";
 import Variable, {TYPE_IMPLICIT, variable_invalidate} from "./variable";
@@ -18,6 +19,10 @@ export default function Runtime(builtins) {
     (new Variable(TYPE_IMPLICIT, builtin)).define(name, [], builtins[name]);
   }
 }
+
+Object.defineProperties(Runtime, {
+  load: {value: load, writable: true, configurable: true}
+});
 
 Object.defineProperties(Runtime.prototype, {
   _compute: {value: runtime_compute, writable: true, configurable: true},

--- a/test/load-test.js
+++ b/test/load-test.js
@@ -1,9 +1,9 @@
 import {RuntimeError} from "../src/errors";
-import {load} from "../src/index";
+import load from "../src/load";
 import tape from "./tape";
 
 tape("basic notebook as module loading", {html: "<div id=foo />"}, async test => {
-  load({id: "notebook@1", modules: [{
+  load({}, {id: "notebook@1", modules: [{
     id: "notebook@1",
     variables: [{
       name: "foo",
@@ -15,7 +15,7 @@ tape("basic notebook as module loading", {html: "<div id=foo />"}, async test =>
 });
 
 tape("notebooks as modules with variables depending on other variables", {html: "<div id=foo />"}, async test => {
-  load({id: "notebook@1", modules: [{
+  load({}, {id: "notebook@1", modules: [{
     id: "notebook@1",
     variables: [{
       name: "foo",
@@ -32,7 +32,7 @@ tape("notebooks as modules with variables depending on other variables", {html: 
 
 tape("throws an error when trying to import from a nonexistent module", {html: "<div id=foo />"}, async test => {
   try {
-    load({id: "notebook@1", modules: [{
+    load({}, {id: "notebook@1", modules: [{
       id: "notebook@1",
       variables: [{
         name: "foo",
@@ -52,7 +52,7 @@ tape("throws an error when trying to import from a nonexistent module", {html: "
 });
 
 // tape.only("notebook as modules with the standard library and views", {html: "<div id=foo /><div id=bar />"}, async test => {
-//   load({id: "notebook@1", modules: [{
+//   load({}, {id: "notebook@1", modules: [{
 //     id: "notebook@1",
 //     variables: [{
 //       name: "foo",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,13 +2,6 @@
 # yarn lockfile v1
 
 
-"@observablehq/notebook-stdlib@https://github.com/observablehq/notebook-stdlib#fb27975":
-  version "0.0.1"
-  resolved "https://github.com/observablehq/notebook-stdlib#fb27975fbf88c82afb46495a3b9157dbebbc16b9"
-  dependencies:
-    d3-require "^0.6.6"
-    esm "^3.0.5"
-
 "@types/node@*":
   version "8.0.53"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-8.0.53.tgz#396b35af826fa66aad472c8cb7b8d5e277f4e6d8"
@@ -284,10 +277,6 @@ cssom@0.3.x, "cssom@>= 0.3.2 < 0.4.0":
   resolved "https://registry.yarnpkg.com/cssstyle/-/cssstyle-0.2.37.tgz#541097234cb2513c83ceed3acddc27ff27987d54"
   dependencies:
     cssom "0.3.x"
-
-d3-require@^0.6.6:
-  version "0.6.6"
-  resolved "https://registry.yarnpkg.com/d3-require/-/d3-require-0.6.6.tgz#cb01119b13d85c81aec97b2f88051731e89bf469"
 
 dashdash@^1.12.0:
   version "1.14.1"


### PR DESCRIPTION
1. Moves load from a top-level export to Runtime.load, a static method. This method now returns a *runtime* instance rather than void.

2. Removes the dependency on notebook-stdlib; instead the *builtins* object is passed as an argument to Runtime.load, as it is to the Runtime constructor.

3. Changes Runtime.load to accept *modules* as any iterable (and likewise *module*.variables as any iterable), rather than requiring these to be arrays.

4. Removes the redundant logic in Runtime.load to support DOM selectors for the *node*, since *module*.variable does that already; as a consequence, Runtime.load now throws an error if you have a broken selector.

5. Updates the README to use hexadecimal identifiers for notebooks, as we plan on doing with the API. Also removes references to *notebook*.runtimeVersion, since this isn’t used anywhere in our code.