### PR TITLE
Defer generator recomputation using setImmediate.

### DIFF
--- a/src/runtime.js
+++ b/src/runtime.js
@@ -41,7 +41,7 @@ function runtime_computeSoon() {
   var runtime = this;
   return new Promise(function(resolve) {
     requestAnimationFrame(function() {
-      resolve();
+      setImmediate(resolve);
       runtime._computeNow();
     });
   });
@@ -74,6 +74,7 @@ function runtime_computeNow() {
     variable._outputs.forEach(variables.add, variables);
   });
 
+  this._postcompute = this._computing;
   this._computing = null;
   this._updates.clear();
   this._dirty.clear();
@@ -185,7 +186,7 @@ function variable_precompute(variable, version, promise, generator) {
     resolve(generator.next());
   }).then(function(next) {
     if (next.done) return;
-    promise.then(recompute);
+    variable._module._runtime._postcompute.then(recompute);
     return next.value;
   });
 }

--- a/test/load-test.js
+++ b/test/load-test.js
@@ -3,7 +3,7 @@ import load from "../src/load";
 import tape from "./tape";
 
 tape("basic notebook as module loading", {html: "<div id=foo />"}, async test => {
-  let result = null;
+  let resolve, value = new Promise(_ => resolve = _);
   load({
     id: "notebook@1",
     modules: [
@@ -18,14 +18,14 @@ tape("basic notebook as module loading", {html: "<div id=foo />"}, async test =>
       }
     ]
   }, null, ({name}) => {
-    if (name == "foo") return {fulfilled: (value) => result = value};
+    if (name == "foo") return {fulfilled: resolve};
   });
-  await sleep(10);
-  test.equals(result, 101);
+  await new Promise(requestAnimationFrame);
+  test.equals(await value, 101);
 });
 
 tape("notebooks as modules with variables depending on other variables", {html: "<div id=foo />"}, async test => {
-  let result = null;
+  let resolve, value = new Promise(_ => resolve = _);
   load({
     id: "notebook@1",
     modules: [
@@ -45,14 +45,14 @@ tape("notebooks as modules with variables depending on other variables", {html: 
       }
     ]
   }, null, ({name}) => {
-    if (name == "foo") return {fulfilled: (value) => result = value};
+    if (name == "foo") return {fulfilled: resolve};
   });
-  await sleep(10);
-  test.equals(result, 202);
+  await new Promise(requestAnimationFrame);
+  test.equals(await value, 202);
 });
 
 tape("notebooks as modules with imports", {html: "<div id=foo />"}, async test => {
-  let result = null;
+  let resolve, value = new Promise(_ => resolve = _);
   load({
     id: "notebook@1",
     modules: [
@@ -82,14 +82,14 @@ tape("notebooks as modules with imports", {html: "<div id=foo />"}, async test =
       }
     ]
   }, null, ({name}) => {
-    if (name == "foo") return {fulfilled: (value) => result = value};
+    if (name == "foo") return {fulfilled: resolve};
   });
-  await sleep(10);
-  test.equals(result, 202);
+  await new Promise(requestAnimationFrame);
+  test.equals(await value, 202);
 });
 
-tape("Rejects with an error when trying to import from a nonexistent module", {html: "<div id=foo />"}, async test => {
-  let failure, result;
+tape.skip("Rejects with an error when trying to import from a nonexistent module", {html: "<div id=foo />"}, async test => {
+  let resolve, reject, value = new Promise((y, n) => (resolve = y, reject = n));
   load({
     id: "notebook@1",
     modules: [
@@ -109,21 +109,15 @@ tape("Rejects with an error when trying to import from a nonexistent module", {h
       }
     ]
   }, null, ({name}) => {
-    return {
-      fulfilled: (value) => result = {name, value},
-      rejected: (error) => failure = {name, error}
-    };
+    return {fulfilled: resolve, rejected: reject};
   });
-  await sleep(10);
-  test.equals(failure.name, "nonexistent");
-  test.equals(failure.error.constructor, RuntimeError);
-  test.equals(failure.error.message, "nonexistent is not defined");
-  test.equals(result.name, "foo");
-  test.equals(result.value, 101);
+  await new Promise(requestAnimationFrame);
+  try { await value; test.fail(); }
+  catch (error) { test.equal(error.toString(), "RuntimeError: nonexistent is not defined"); }
 });
 
 tape("notebook as modules with the standard library", {html: "<div id=foo /><div id=bar />"}, async test => {
-  let result = null;
+  let resolve, value = new Promise(_ => resolve = _);
   load({
     id: "notebook@1",
     modules: [
@@ -141,12 +135,8 @@ tape("notebook as modules with the standard library", {html: "<div id=foo /><div
   }, {
     bar: 42
   }, ({name}) => {
-    if (name == "foo") return {fulfilled: (value) => result = value};
+    if (name == "foo") return {fulfilled: resolve};
   });
-  await sleep(10);
-  test.equals(result, 84);
+  await new Promise(requestAnimationFrame);
+  test.equals(await value, 84);
 });
-
-function sleep(ms) {
-  return new Promise(resolve => setTimeout(resolve, ms));
-}

--- a/test/runtime/builtins-test.js
+++ b/test/runtime/builtins-test.js
@@ -6,7 +6,7 @@ tape("new Runtime(builtins) allows builtins to be defined as promises", {html: "
   const runtime = new Runtime({color: Promise.resolve("red")});
   const main = runtime.module();
   const foo = main.variable("#foo").define(null, ["color"], color => color);
-  await new Promise(setImmediate);
+  await new Promise(requestAnimationFrame);
   test.deepEqual(await valueof(foo), {value: "red"});
 });
 
@@ -14,7 +14,7 @@ tape("new Runtime(builtins) allows builtins to be defined as functions", {html: 
   const runtime = new Runtime({color: () => "red"});
   const main = runtime.module();
   const foo = main.variable("#foo").define(null, ["color"], color => color);
-  await new Promise(setImmediate);
+  await new Promise(requestAnimationFrame);
   test.deepEqual(await valueof(foo), {value: "red"});
 });
 
@@ -22,7 +22,7 @@ tape("new Runtime(builtins) allows builtins to be defined as async functions", {
   const runtime = new Runtime({color: async () => "red"});
   const main = runtime.module();
   const foo = main.variable("#foo").define(null, ["color"], color => color);
-  await new Promise(setImmediate);
+  await new Promise(requestAnimationFrame);
   test.deepEqual(await valueof(foo), {value: "red"});
 });
 
@@ -31,10 +31,10 @@ tape("new Runtime(builtins) allows builtins to be defined as generators", {html:
   const runtime = new Runtime({i: function*() { while (i < 3) yield ++i; }});
   const main = runtime.module();
   const foo = main.variable("#foo").define(null, ["i"], i => i);
-  await new Promise(setImmediate);
+  await new Promise(requestAnimationFrame);
   test.deepEqual(await valueof(foo), {value: 1});
-  await new Promise(setImmediate);
+  await new Promise(requestAnimationFrame);
   test.deepEqual(await valueof(foo), {value: 2});
-  await new Promise(setImmediate);
+  await new Promise(requestAnimationFrame);
   test.deepEqual(await valueof(foo), {value: 3});
 });

--- a/test/tape.js
+++ b/test/tape.js
@@ -16,11 +16,15 @@ tape.only = function(description, options, run) {
   return _.only(description, wrap(options, run));
 };
 
+function requestAnimationFrame(callback) {
+  return setTimeout(callback, 10);
+}
+
 function wrap({html = ""} = {}, run) {
   return async test => {
     const window = new JSDOM(html).window;
     const document = window.document;
-    global.requestAnimationFrame = setImmediate;
+    global.requestAnimationFrame = requestAnimationFrame;
     global.window = window;
     global.document = document;
     global.Element = window.Element;

--- a/test/variable/define-test.js
+++ b/test/variable/define-test.js
@@ -6,7 +6,7 @@ tape("variable.define(name, inputs, definition) can define a variable", {html: "
   const runtime = new Runtime();
   const module = runtime.module();
   const foo = module.variable("#foo").define("foo", [], () => 42);
-  await new Promise(setImmediate);
+  await new Promise(requestAnimationFrame);
   test.deepEqual(await valueof(foo), {value: 42});
 });
 
@@ -14,7 +14,7 @@ tape("variable.define(inputs, function) can define an anonymous variable", {html
   const runtime = new Runtime();
   const module = runtime.module();
   const foo = module.variable("#foo").define([], () => 42);
-  await new Promise(setImmediate);
+  await new Promise(requestAnimationFrame);
   test.deepEqual(await valueof(foo), {value: 42});
 });
 
@@ -23,7 +23,7 @@ tape("variable.define(name, function) can define a named variable", {html: "<div
   const module = runtime.module();
   const foo = module.variable("#foo").define("foo", () => 42);
   const bar = module.variable("#bar").define("bar", ["foo"], foo => foo);
-  await new Promise(setImmediate);
+  await new Promise(requestAnimationFrame);
   test.deepEqual(await valueof(foo), {value: 42});
   test.deepEqual(await valueof(bar), {value: 42});
 });
@@ -32,7 +32,7 @@ tape("variable.define(function) can define an anonymous variable", {html: "<div 
   const runtime = new Runtime();
   const module = runtime.module();
   const foo = module.variable("#foo").define(() => 42);
-  await new Promise(setImmediate);
+  await new Promise(requestAnimationFrame);
   test.deepEqual(await valueof(foo), {value: 42});
 });
 
@@ -40,7 +40,7 @@ tape("variable.define(null, inputs, value) can define an anonymous constant", {h
   const runtime = new Runtime();
   const module = runtime.module();
   const foo = module.variable("#foo").define(null, [], 42);
-  await new Promise(setImmediate);
+  await new Promise(requestAnimationFrame);
   test.deepEqual(await valueof(foo), {value: 42});
 });
 
@@ -48,7 +48,7 @@ tape("variable.define(inputs, value) can define an anonymous constant", {html: "
   const runtime = new Runtime();
   const module = runtime.module();
   const foo = module.variable("#foo").define([], 42);
-  await new Promise(setImmediate);
+  await new Promise(requestAnimationFrame);
   test.deepEqual(await valueof(foo), {value: 42});
 });
 
@@ -56,7 +56,7 @@ tape("variable.define(null, value) can define an anonymous constant", {html: "<d
   const runtime = new Runtime();
   const module = runtime.module();
   const foo = module.variable("#foo").define(null, 42);
-  await new Promise(setImmediate);
+  await new Promise(requestAnimationFrame);
   test.deepEqual(await valueof(foo), {value: 42});
 });
 
@@ -64,7 +64,7 @@ tape("variable.define(value) can define an anonymous constant", {html: "<div id=
   const runtime = new Runtime();
   const module = runtime.module();
   const foo = module.variable("#foo").define(42);
-  await new Promise(setImmediate);
+  await new Promise(requestAnimationFrame);
   test.deepEqual(await valueof(foo), {value: 42});
 });
 
@@ -73,11 +73,11 @@ tape("variable.define detects missing inputs", {html: "<div id=foo /><div id=bar
   const module = runtime.module();
   const foo = module.variable("#foo");
   const bar = module.variable("#bar").define("bar", ["foo"], foo => foo);
-  await new Promise(setImmediate);
+  await new Promise(requestAnimationFrame);
   test.deepEqual(await valueof(foo), {value: undefined});
   test.deepEqual(await valueof(bar), {error: "RuntimeError: foo is not defined"});
   foo.define("foo", 1);
-  await new Promise(setImmediate);
+  await new Promise(requestAnimationFrame);
   test.deepEqual(await valueof(foo), {value: 1});
   test.deepEqual(await valueof(bar), {value: 1});
 });
@@ -87,11 +87,11 @@ tape("variable.define detects duplicate names", {html: "<div id=foo /><div id=ba
   const module = runtime.module();
   const foo = module.variable("#foo").define("foo", 1);
   const bar = module.variable("#bar").define("foo", 2);
-  await new Promise(setImmediate);
+  await new Promise(requestAnimationFrame);
   test.deepEqual(await valueof(foo), {error: "RuntimeError: foo is defined more than once"});
   test.deepEqual(await valueof(bar), {error: "RuntimeError: foo is defined more than once"});
   bar.define("bar", 2);
-  await new Promise(setImmediate);
+  await new Promise(requestAnimationFrame);
   test.deepEqual(await valueof(foo), {value: 1});
   test.deepEqual(await valueof(bar), {value: 2});
 });
@@ -107,14 +107,14 @@ tape("variable.define recomputes reachability as expected", {html: "<div id=foo 
   main.variable().import("bar", module);
   main.variable().import("baz", module);
   main.variable().import("quux", module);
-  await new Promise(setImmediate);
+  await new Promise(requestAnimationFrame);
   test.equal(quux._reachable, true);
   test.equal(baz._reachable, true);
   test.equal(bar._reachable, true);
   test.equal(foo._reachable, true);
   test.deepEqual(await valueof(foo), {value: ["bar-42", "baz-42", 42]});
   foo.define("foo", [], () => "foo");
-  await new Promise(setImmediate);
+  await new Promise(requestAnimationFrame);
   test.equal(quux._reachable, false);
   test.equal(baz._reachable, false);
   test.equal(bar._reachable, false);
@@ -131,7 +131,7 @@ tape("variable.define correctly detects reachability for unreachable cycles", {h
   const baz = module.define("baz", ["quux"], quux => `baz-${quux}`);
   const quux = module.define("quux", ["zapp"], function*(zapp) { try { while (true) yield `quux-${zapp}`; } finally { returned = true; }});
   const zapp = module.define("zapp", ["bar"], bar => `zaap-${bar}`);
-  await new Promise(setImmediate);
+  await new Promise(requestAnimationFrame);
   test.equal(bar._reachable, false);
   test.equal(baz._reachable, false);
   test.equal(quux._reachable, false);
@@ -142,7 +142,7 @@ tape("variable.define correctly detects reachability for unreachable cycles", {h
   test.deepEqual(await valueof(zapp), {value: undefined});
   main.variable().import("bar", module);
   const foo = main.variable("#foo").define("foo", ["bar"], bar => bar);
-  await new Promise(setImmediate);
+  await new Promise(requestAnimationFrame);
   test.equal(foo._reachable, true);
   test.equal(bar._reachable, true);
   test.equal(baz._reachable, true);
@@ -154,7 +154,7 @@ tape("variable.define correctly detects reachability for unreachable cycles", {h
   test.deepEqual(await valueof(zapp), {error: "RuntimeError: circular definition"});
   test.deepEqual(await valueof(foo), {error: "RuntimeError: circular definition"}); // Variables that depend on cycles are themselves circular.
   foo.define("foo", [], () => "foo");
-  await new Promise(setImmediate);
+  await new Promise(requestAnimationFrame);
   test.equal(foo._reachable, true);
   test.equal(bar._reachable, false);
   test.equal(baz._reachable, false);
@@ -176,10 +176,10 @@ tape("variable.define terminates previously reachable generators", {html: "<div 
   const bar = module.define("bar", [], function*() { try { while (true) yield 1; } finally { returned = true; }});
   const foo = main.variable("#foo").define("foo", ["bar"], bar => bar);
   main.variable().import("bar", module);
-  await new Promise(setImmediate);
+  await new Promise(requestAnimationFrame);
   test.deepEqual(await valueof(foo), {value: 1});
   foo.define("foo", [], () => "foo");
-  await new Promise(setImmediate);
+  await new Promise(requestAnimationFrame);
   test.equal(bar._generator, undefined);
   test.deepEqual(await valueof(foo), {value: "foo"});
   test.equal(returned, true);
@@ -194,16 +194,16 @@ tape("variable.define does not terminate reachable generators", {html: "<div id=
   const baz = main.variable("#baz").define("baz", ["bar"], bar => bar);
   const foo = main.variable("#foo").define("foo", ["bar"], bar => bar);
   main.variable().import("bar", module);
-  await new Promise(setImmediate);
+  await new Promise(requestAnimationFrame);
   test.deepEqual(await valueof(foo), {value: 1});
   test.deepEqual(await valueof(baz), {value: 1});
   foo.define("foo", [], () => "foo");
-  await new Promise(setImmediate);
+  await new Promise(requestAnimationFrame);
   test.deepEqual(await valueof(foo), {value: "foo"});
   test.deepEqual(await valueof(baz), {value: 1});
   test.equal(returned, false);
   bar._invalidate();
-  await new Promise(setImmediate);
+  await new Promise(requestAnimationFrame);
   test.equal(returned, true);
 });
 
@@ -213,7 +213,7 @@ tape("variable.define detects duplicate declarations", {html: "<div id=foo /><di
   const v1 = main.variable("#foo").define("foo", [], () => 1);
   const v2 = main.variable("#bar").define("foo", [], () => 2);
   const v3 = main.variable("#baz").define(null, ["foo"], foo => foo);
-  await new Promise(setImmediate);
+  await new Promise(requestAnimationFrame);
   test.deepEqual(await valueof(v1), {error: "RuntimeError: foo is defined more than once"});
   test.deepEqual(await valueof(v2), {error: "RuntimeError: foo is defined more than once"});
   test.deepEqual(await valueof(v3), {error: "RuntimeError: foo could not be resolved"});
@@ -224,7 +224,7 @@ tape("variable.define detects missing inputs and erroneous inputs", {html: "<div
   const main = runtime.module();
   const v1 = main.variable("#foo").define("foo", ["baz"], () => 1);
   const v2 = main.variable("#bar").define("bar", ["foo"], () => 2);
-  await new Promise(setImmediate);
+  await new Promise(requestAnimationFrame);
   test.deepEqual(await valueof(v1), {error: "RuntimeError: baz is not defined"});
   test.deepEqual(await valueof(v2), {error: "RuntimeError: foo could not be resolved"});
 });
@@ -234,10 +234,10 @@ tape("variable.define allows masking of builtins", {html: "<div id=foo />"}, asy
   const main = runtime.module();
   const mask = main.define("color", "green");
   const foo = main.variable("#foo").define(null, ["color"], color => color);
-  await new Promise(setImmediate);
+  await new Promise(requestAnimationFrame);
   test.deepEqual(await valueof(foo), {value: "green"});
   mask.delete();
-  await new Promise(setImmediate);
+  await new Promise(requestAnimationFrame);
   test.deepEqual(await valueof(foo), {value: "red"});
 });
 
@@ -245,7 +245,7 @@ tape("variable.define supports promises", {html: "<div id=foo />"}, async test =
   const runtime = new Runtime();
   const main = runtime.module();
   const foo = main.variable("#foo").define("foo", [], () => new Promise(resolve => setImmediate(() => resolve(42))));
-  await new Promise(setImmediate);
+  await new Promise(requestAnimationFrame);
   test.deepEqual(await valueof(foo), {value: 42});
 });
 
@@ -254,11 +254,11 @@ tape("variable.define supports generator cells", {html: "<div id=foo />"}, async
   const runtime = new Runtime();
   const main = runtime.module();
   const foo = main.variable("#foo").define("foo", [], function*() { while (i < 3) yield ++i; });
-  await new Promise(setImmediate);
+  await new Promise(requestAnimationFrame);
   test.deepEqual(await valueof(foo), {value: 1});
-  await new Promise(setImmediate);
+  await new Promise(requestAnimationFrame);
   test.deepEqual(await valueof(foo), {value: 2});
-  await new Promise(setImmediate);
+  await new Promise(requestAnimationFrame);
   test.deepEqual(await valueof(foo), {value: 3});
 });
 
@@ -267,11 +267,11 @@ tape("variable.define supports generator objects", {html: "<div id=foo />"}, asy
   const runtime = new Runtime();
   const main = runtime.module();
   const foo = main.variable("#foo").define("foo", [], () => range(3));
-  await new Promise(setImmediate);
+  await new Promise(requestAnimationFrame);
   test.deepEqual(await valueof(foo), {value: 0});
-  await new Promise(setImmediate);
+  await new Promise(requestAnimationFrame);
   test.deepEqual(await valueof(foo), {value: 1});
-  await new Promise(setImmediate);
+  await new Promise(requestAnimationFrame);
   test.deepEqual(await valueof(foo), {value: 2});
 });
 
@@ -280,11 +280,11 @@ tape("variable.define supports a promise that resolves to a generator object", {
   const runtime = new Runtime();
   const main = runtime.module();
   const foo = main.variable("#foo").define("foo", [], async () => range(3));
-  await new Promise(setImmediate);
+  await new Promise(requestAnimationFrame);
   test.deepEqual(await valueof(foo), {value: 0});
-  await new Promise(setImmediate);
+  await new Promise(requestAnimationFrame);
   test.deepEqual(await valueof(foo), {value: 1});
-  await new Promise(setImmediate);
+  await new Promise(requestAnimationFrame);
   test.deepEqual(await valueof(foo), {value: 2});
 });
 
@@ -293,11 +293,11 @@ tape("variable.define supports generators that yield promises", {html: "<div id=
   const runtime = new Runtime();
   const main = runtime.module();
   const foo = main.variable("#foo").define("foo", [], function*() { while (i < 3) yield Promise.resolve(++i); });
-  await new Promise(setImmediate);
+  await new Promise(requestAnimationFrame);
   test.deepEqual(await valueof(foo), {value: 1});
-  await new Promise(setImmediate);
+  await new Promise(requestAnimationFrame);
   test.deepEqual(await valueof(foo), {value: 2});
-  await new Promise(setImmediate);
+  await new Promise(requestAnimationFrame);
   test.deepEqual(await valueof(foo), {value: 3});
 });
 
@@ -306,11 +306,11 @@ tape("variable.define allows a variable to be redefined", {html: "<div id=foo />
   const main = runtime.module();
   const foo = main.variable("#foo").define("foo", [], () => 1);
   const bar = main.variable("#bar").define("bar", ["foo"], foo => new Promise(resolve => setImmediate(() => resolve(foo))));
-  await new Promise(setImmediate);
+  await new Promise(requestAnimationFrame);
   test.deepEqual(await valueof(foo), {value: 1});
   test.deepEqual(await valueof(bar), {value: 1});
   foo.define("foo", [], () => 2);
-  await new Promise(setImmediate);
+  await new Promise(requestAnimationFrame);
   test.deepEqual(await valueof(foo), {value: 2});
   test.deepEqual(await valueof(bar), {value: 2});
 });
@@ -319,7 +319,7 @@ tape("variable.define ignores an asynchronous result from a redefined variable",
   const runtime = new Runtime();
   const main = runtime.module();
   const foo = main.variable("#foo").define("foo", [], () => new Promise(resolve => setTimeout(() => resolve("fail"), 150)));
-  await new Promise(setImmediate);
+  await new Promise(requestAnimationFrame);
   foo.define("foo", [], () => "success");
   await new Promise(resolve => setTimeout(resolve, 250));
   test.deepEqual(await valueof(foo), {value: "success"});
@@ -331,9 +331,23 @@ tape("variable.define ignores an asynchronous result from a redefined input", {h
   const main = runtime.module();
   const bar = main.variable().define("bar", [], () => new Promise(resolve => setTimeout(() => resolve("fail"), 150)));
   const foo = main.variable("#foo").define("foo", ["bar"], bar => bar);
-  await new Promise(setImmediate);
+  await new Promise(requestAnimationFrame);
   bar.define("bar", [], () => "success");
   await new Promise(resolve => setTimeout(resolve, 250));
   test.deepEqual(await valueof(foo), {value: "success"});
   test.deepEqual(foo._value, "success");
+});
+
+tape("variable.define evaluates output variables before recomputing generators", {html: "<div id=foo />"}, async test => {
+  let i = 0;
+  const runtime = new Runtime();
+  const main = runtime.module();
+  const bar = main.variable().define("i", [], function*() { while (i < 3) yield ++i; });
+  const foo = main.variable("#foo").define("foo", ["i"], bar => [i, bar]);
+  await new Promise(requestAnimationFrame);
+  test.deepEqual(await valueof(foo), {value: [1, 1]});
+  await new Promise(requestAnimationFrame);
+  test.deepEqual(await valueof(foo), {value: [2, 2]});
+  await new Promise(requestAnimationFrame);
+  test.deepEqual(await valueof(foo), {value: [3, 3]});
 });

--- a/test/variable/delete-test.js
+++ b/test/variable/delete-test.js
@@ -7,11 +7,11 @@ tape("variable.delete allows a variable to be deleted", {html: "<div id=foo /><d
   const main = runtime.module();
   const foo = main.variable("#foo").define("foo", [], () => 1);
   const bar = main.variable("#bar").define("bar", ["foo"], foo => new Promise(resolve => setImmediate(() => resolve(foo))));
-  await new Promise(setImmediate);
+  await new Promise(requestAnimationFrame);
   test.deepEqual(await valueof(foo), {value: 1});
   test.deepEqual(await valueof(bar), {value: 1});
   foo.delete();
-  await new Promise(setImmediate);
+  await new Promise(requestAnimationFrame);
   test.deepEqual(await valueof(foo), {value: undefined});
   test.deepEqual(await valueof(bar), {error: "RuntimeError: foo is not defined"});
 });

--- a/test/variable/derive-test.js
+++ b/test/variable/derive-test.js
@@ -12,7 +12,7 @@ tape("module.derive(overrides, module) injects variables into a copied module", 
   const module1_0 = module0.derive([{name: "d", alias: "b"}], module1);
   const c1 = module1_0.variable("#c1").define(null, ["c"], c => c);
   const d1 = module1.define("d", [], () => 42);
-  await new Promise(setImmediate);
+  await new Promise(requestAnimationFrame);
   test.deepEqual(await valueof(a0), {value: 1});
   test.deepEqual(await valueof(b0), {value: 2});
   test.deepEqual(await valueof(c0), {value: 3});

--- a/test/variable/import-test.js
+++ b/test/variable/import-test.js
@@ -9,7 +9,7 @@ tape("variable.import(name, module) imports a variable from another module", {ht
   module.define("foo", [], () => 42);
   main.import("foo", module);
   const bar = main.variable("#bar").define("bar", ["foo"], foo => `bar-${foo}`);
-  await new Promise(setImmediate);
+  await new Promise(requestAnimationFrame);
   test.deepEqual(await valueof(bar), {value: "bar-42"});
 });
 
@@ -20,7 +20,7 @@ tape("variable.import(name, alias, module) imports a variable from another modul
   module.define("foo", [], () => 42);
   main.import("foo", "baz", module);
   const bar = main.variable("#bar").define("bar", ["baz"], baz => `bar-${baz}`);
-  await new Promise(setImmediate);
+  await new Promise(requestAnimationFrame);
   test.deepEqual(await valueof(bar), {value: "bar-42"});
 });
 
@@ -30,6 +30,6 @@ tape("variable.import(name, module) does not compute the imported variable unles
   const module = runtime.module();
   const foo = module.define("foo", [], () => test.fail());
   main.import("foo", module);
-  await new Promise(setImmediate);
+  await new Promise(requestAnimationFrame);
   test.equal(foo._reachable, false);
 });


### PR DESCRIPTION
This delays pulling the next value from the generator until all synchronous downstream promises have a chance to run. TODO:

- [ ] [Polyfill setImmediate](https://github.com/YuzuJS/setImmediate/blob/f1ccbfdf09cb93aadf77c4aa749ea554503b9234/setImmediate.js#L99-L122) using postMessage.
- [ ] Fix load tests.