### PR TITLE
Add an unreachable output test.

### DIFF
--- a/test/runtime/builtins-test.js
+++ b/test/runtime/builtins-test.js
@@ -1,4 +1,4 @@
-import {Runtime} from "../../";
+import {Runtime} from "../../src/";
 import tape from "../tape";
 import valueof from "../variable/valueof";
 

--- a/test/variable/delete-test.js
+++ b/test/variable/delete-test.js
@@ -1,4 +1,4 @@
-import {Runtime} from "../../";
+import {Runtime} from "../../src/";
 import tape from "../tape";
 import valueof from "./valueof";
 

--- a/test/variable/derive-test.js
+++ b/test/variable/derive-test.js
@@ -1,4 +1,4 @@
-import {Runtime} from "../../";
+import {Runtime} from "../../src/";
 import tape from "../tape";
 import valueof from "./valueof";
 

--- a/test/variable/import-test.js
+++ b/test/variable/import-test.js
@@ -1,4 +1,4 @@
-import {Runtime} from "../../";
+import {Runtime} from "../../src/";
 import tape from "../tape";
 import valueof from "./valueof";
 


### PR DESCRIPTION
Adds a test (which fails on **master**) to ensure that unreachable variables that are outputs of other, reachable variables, don't attempt computation.

Also tests against the raw code in `src/` instead of packaged `dist/`, which was a result of our "main" change.