### PR TITLE
Make runtime.main accessible from Runtime.load()

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,14 @@ Builtins must have constant values; unlike [variables](#variables), they cannot 
 
 Returns a new [module](#modules) for this [runtime](#runtimes).
 
+<a href="#runtime_main" name="runtime_main">#</a> <i>runtime</i>.<b>main</b> [<>](https://github.com/observablehq/notebook-runtime/blob/master/src/load.js "Source")
+
+If the runtime was loaded with [Runtime.load()](#Runtime_load), `runtime.main` becomes available as a reference to the runtime’s main [module](#modules). The main module can then be used to [redefine](#module_redefine) variables:
+
+```js
+runtime.main.redefine("hello", ["color"], color => `My favorite color is: ${color}.`);
+```
+
 ### Modules
 
 A module is a namespace for [variables](#variables); within a module, variables should typically have unique names. [Imports](#variable_import) allow variables to be referenced across modules.
@@ -166,6 +174,15 @@ A convenience method for [*variable*.define](#variable_define); equivalent to:
 
 ```js
 module.variable().define(name, inputs, definition)
+```
+
+<a href="#module_redefine" name="module_redefine">#</a> <i>module</i>.<b>redefine</b>(<i>name</i>, \[<i>inputs</i>, \]<i>definition</i>) [<>](https://github.com/observablehq/notebook-runtime/blob/master/src/module.js "Source")
+
+A convenience method to redefine an existing, named variable in the module. Given a module with defined `"hello"` and `"a"` variables:
+
+```js
+module.redefine("hello", [name], (name) => `Hello, ${name}`);
+module.redefine("a", () => 2);
 ```
 
 <a href="#module_import" name="module_import">#</a> <i>module</i>.<b>import</b>(<i>name</i>, [<i>alias</i>, ]<i>from</i>) [<>](https://github.com/observablehq/notebook-runtime/blob/master/src/module.js "Source")

--- a/src/load.js
+++ b/src/load.js
@@ -9,7 +9,7 @@ export default function load(notebook, library, observer) {
   const {modules, id} = notebook;
   const map = new Map;
   const runtime = new Runtime(library);
-  const main = runtime_module(id);
+  runtime.main = runtime_module(id);
 
   function runtime_module(id) {
     let module = map.get(id);
@@ -22,7 +22,7 @@ export default function load(notebook, library, observer) {
     let i = 0;
     for (const v of m.variables) {
       if (v.from) module.import(v.remote, v.name, runtime_module(v.from));
-      else if (module === main) module.variable(observer(v, i, m.variables)).define(v.name, v.inputs, v.value);
+      else if (module === runtime.main) module.variable(observer(v, i, m.variables)).define(v.name, v.inputs, v.value);
       else module.define(v.name, v.inputs, v.value);
       ++i;
     }

--- a/src/module.js
+++ b/src/module.js
@@ -1,4 +1,5 @@
 import {forEach} from "./array";
+import {RuntimeError} from "./errors";
 import identity from "./identity";
 import Variable, {TYPE_IMPLICIT, TYPE_NORMAL} from "./variable";
 
@@ -17,6 +18,7 @@ Object.defineProperties(Module.prototype, {
   define: {value: module_define, writable: true, configurable: true},
   derive: {value: module_derive, writable: true, configurable: true},
   import: {value: module_import, writable: true, configurable: true},
+  redefine: {value: module_redefine, writable: true, configurable: true},
   variable: {value: module_variable, writable: true, configurable: true}
 });
 
@@ -32,6 +34,12 @@ function module_import() {
 
 function module_variable(observer) {
   return new Variable(TYPE_NORMAL, this, observer);
+}
+
+function module_redefine(name) {
+  var v = this._scope.get(name);
+  if (!v) throw new RuntimeError(name + " is not defined", name);
+  return v.define.apply(v, arguments);
 }
 
 function module_derive(injects, injectModule) {

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -11,7 +11,8 @@ export default function Runtime(builtins) {
     _dirty: {value: new Set},
     _updates: {value: new Set},
     _computing: {value: null, writable: true},
-    _builtin: {value: builtin}
+    _builtin: {value: builtin},
+    main: {value: null, writable: true}
   });
   if (builtins) for (var name in builtins) {
     (new Variable(TYPE_IMPLICIT, builtin)).define(name, [], builtins[name]);

--- a/test/load-test.js
+++ b/test/load-test.js
@@ -168,6 +168,34 @@ tape("notebook with the default standard library", {html: "<div id=foo /><div id
   test.equals(result.outerHTML, '<div></div>');
 });
 
+tape("after Runtime.load, the main module can be used to redefine variables with new definitions", {html: "<div id=foo />"}, async test => {
+  let result = null;
+  const runtime = load({
+    id: "notebook@1",
+    modules: [
+      {
+        id: "notebook@1",
+        variables: [
+          {
+            name: "foo",
+            value: () => 101
+          }
+        ]
+      }
+    ]
+  }, null, ({name}) => {
+    if (name == "foo") return {fulfilled: (value) => result = value};
+  });
+  await sleep(10);
+  test.equals(result, 101);
+  test.equals(runtime.main._resolve("foo")._value, 101);
+
+  runtime.main.redefine("foo", [], () => 202);
+  await sleep(10);
+  test.equals(result, 202);
+  test.equals(runtime.main._resolve("foo")._value, 202);
+});
+
 function sleep(ms) {
   return new Promise(resolve => setTimeout(resolve, ms));
 }

--- a/test/load-test.js
+++ b/test/load-test.js
@@ -3,7 +3,7 @@ import tape from "./tape";
 
 tape("basic notebook as module loading", {html: "<div id=foo />"}, async test => {
   let result = null;
-  load({
+  const runtime = load({
     id: "notebook@1",
     modules: [
       {
@@ -21,6 +21,7 @@ tape("basic notebook as module loading", {html: "<div id=foo />"}, async test =>
   });
   await sleep(10);
   test.equals(result, 101);
+  test.equals(runtime.main._resolve("foo")._value, 101);
 });
 
 tape("notebooks as modules with variables depending on other variables", {html: "<div id=foo />"}, async test => {

--- a/test/module/redefine-test.js
+++ b/test/module/redefine-test.js
@@ -1,0 +1,30 @@
+import {Runtime} from "../../src/";
+import {RuntimeError} from "../../src/errors";
+import tape from "../tape";
+import valueof from "../variable/valueof";
+
+tape("module.redefine(name, inputs, definition) can redefine an existing variable", {html: "<div id=foo />"}, async test => {
+  const runtime = new Runtime();
+  const module = runtime.module();
+  const foo = module.variable("#foo").define("foo", [], () => 42);
+  await new Promise(setImmediate);
+  test.deepEqual(await valueof(foo), {value: 42});
+  module.redefine("foo", [], () => 43);
+  await new Promise(setImmediate);
+  test.deepEqual(await valueof(foo), {value: 43});
+  module.redefine("foo", () => 44);
+  await new Promise(setImmediate);
+  test.deepEqual(await valueof(foo), {value: 44});
+});
+
+tape("module.redefine(name, inputs, function) throws an error when attempting to redefine a nonexistent variable", {html: "<div id=foo />"}, async test => {
+  const runtime = new Runtime();
+  const module = runtime.module();
+  await new Promise(setImmediate);
+  try {
+    module.redefine("foo", [], () => 1);
+  } catch (e) {
+    test.equals(e.constructor, RuntimeError);
+    test.equals(e.message, "foo is not defined");
+  }
+});


### PR DESCRIPTION
As discussed, exposes the main module when you `Runtime.load()` a notebook.

This allows you to more easily redefine variables from outside ... without having to navigate the private tree of modules and variables.