### PR TITLE
Add runtime.dispose.

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,10 @@ If *define* is specified, it is a function which defines the new module’s [var
 
 If an *observer* factory function is specified, it is called for each named variable in the returned module, being passed the variable’s name. The [standard inspector](#inspector) is available as a ready-made observer: it displays DOM elements “as-is” and renders interactive displays for other arbitrary values such as numbers and objects.
 
+<a href="#runtime_dispose" name="runtime_dispose">#</a> <i>runtime</i>.<b>dispose</b>() [<>](https://github.com/observablehq/runtime/blob/master/src/runtime.js "Source")
+
+Disposes this runtime, invalidating all active variables and disabling future computation.
+
 ### Modules
 
 A module is a namespace for [variables](#variables); within a module, variables should typically have unique names. [Imports](#variable_import) allow variables to be referenced across modules.

--- a/src/variable.js
+++ b/src/variable.js
@@ -97,6 +97,10 @@ function variable_defineImpl(name, inputs, definition) {
   this._definition = definition;
   this._value = undefined;
 
+  // Is this an active variable (that may require disposal)?
+  if (definition === noop) runtime._variables.delete(this);
+  else runtime._variables.add(this);
+
   // Did the variable’s name change? Time to patch references!
   if (name == this._name && scope.get(name) === this) {
     this._outputs.forEach(runtime._updates.add, runtime._updates);

--- a/test/dispose.html
+++ b/test/dispose.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<script type=module>
+
+import {Runtime, Inspector} from "/dist/runtime.js";
+
+const runtime = new Runtime();
+const main = runtime.module();
+
+main.variable(true).define(["invalidation"], async invalidation => {
+  await invalidation;
+  console.log("invalidation");
+});
+
+main.variable(true).define([], function*() {
+  try { while (true) yield; }
+  finally { console.log("return"); }
+});
+
+setTimeout(() => runtime.dispose(), 1000);
+
+</script>


### PR DESCRIPTION
Fixes #147. Any active variable is invalidated, and its version is set to NaN to prevent it from being computed (if it is not yet computed), and to prevent further values from being drawn from generators.