### PR TITLE
Don’t compute unreachable outputs.

### DIFF
--- a/src/runtime.js
+++ b/src/runtime.js
@@ -112,7 +112,7 @@ function runtime_computeNow() {
       variable._indegree = 0;
       variable._outputs.forEach(variables.add, variables);
     } else {
-      variable._indegree = -1;
+      variable._indegree = NaN;
       variables.delete(variable);
     }
   });

--- a/src/variable.js
+++ b/src/variable.js
@@ -17,7 +17,7 @@ export default function Variable(type, module, observer) {
     _definition: {value: variable_undefined, writable: true},
     _duplicate: {value: undefined, writable: true},
     _duplicates: {value: undefined, writable: true},
-    _indegree: {value: -1, writable: true}, // The number of computing inputs.
+    _indegree: {value: NaN, writable: true}, // The number of computing inputs.
     _inputs: {value: [], writable: true},
     _invalidate: {value: noop, writable: true},
     _module: {value: module},

--- a/test/variable/define-test.js
+++ b/test/variable/define-test.js
@@ -350,6 +350,20 @@ tape("variable.define does not try to compute unreachable variables", async test
   test.equals(evaluated, false);
 });
 
+tape("variable.define does not try to compute unreachable variables that are outputs of reachable variables", async test => {
+  const runtime = new Runtime();
+  const main = runtime.module();
+  let evaluated = false;
+  const foo = main.variable(true).define("foo", [], () => 1);
+  const bar = main.variable(true).define("bar", [], () => 2);
+  const baz = main.variable().define("baz", ["foo", "bar"], (foo, bar) => evaluated = foo + bar);
+  await new Promise(setImmediate);
+  test.deepEqual(await valueof(foo), {value: 1});
+  test.deepEqual(await valueof(bar), {value: 2});
+  test.deepEqual(await valueof(baz), {value: undefined});
+  test.equals(evaluated, false);
+});
+
 tape("variable.define can reference whitelisted globals", async test => {
   const runtime = new Runtime(null, name => name === "magic" ? 21 : undefined);
   const module = runtime.module();


### PR DESCRIPTION
Previously, a variable that was unreachable but which referenced exactly one reachable variable would be computed. This was not the intent! We set *variable*._indegree to -1 to prevent the variable from being added to the compute queue here:

```js
function postqueue(variable) {
  if (--variable._indegree === 0) {
    queue.push(variable);
  }
}
```

However, if the unreachable variable was an output of exactly one other reachable variable, its indegree would be erroneously incremented back up to 0 here:

```js
// Compute the indegree of updating variables.
variables.forEach(function(variable) {
  variable._outputs.forEach(variable_increment);
});
```

By setting *variable*._indegree to NaN instead of -1, we ensure that this incrementing and decrementing has no effect, and thus the unreachable variable is never computed.

Not computing unreachable variables is important when these variables have side-effects.