### PR TITLE
Fix error for variables that depend on circular definitions.

### DIFF
--- a/src/runtime.js
+++ b/src/runtime.js
@@ -159,12 +159,10 @@ function runtime_computeNow() {
 }
 
 function variable_circular(variable) {
-  const seen = new Set().add(variable);
-  for (const v of seen) {
-    for (const o of v._inputs) {
-      if (o === variable) return true;
-      seen.add(o);
-    }
+  const inputs = new Set(variable._inputs);
+  for (const i of inputs) {
+    if (i === variable) return true;
+    i._inputs.forEach(inputs.add, inputs);
   }
   return false;
 }

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -126,8 +126,7 @@ function runtime_computeNow() {
     variable._outputs.forEach(variable_increment);
   });
 
-  while (variables.size) {
-
+  do {
     // Identify the root variables (those with no updating inputs).
     variables.forEach(function(variable) {
       if (variable._indegree === 0) {
@@ -142,7 +141,7 @@ function runtime_computeNow() {
       variables.delete(variable);
     }
 
-    // Any remaining variables have circular definitions.
+    // Any remaining variables are circular, or depend on them.
     variables.forEach(function(variable) {
       if (variable_circular(variable)) {
         variable_error(variable, new RuntimeError("circular definition"));
@@ -150,7 +149,7 @@ function runtime_computeNow() {
         variables.delete(variable);
       }
     });
-  }
+  } while (variables.size);
 
   function postqueue(variable) {
     if (--variable._indegree === 0) {

--- a/test/variable/define-test.js
+++ b/test/variable/define-test.js
@@ -140,7 +140,7 @@ tape("variable.define correctly detects reachability for unreachable cycles", as
   test.deepEqual(await valueof(baz), {error: "RuntimeError: circular definition"});
   test.deepEqual(await valueof(quux), {error: "RuntimeError: circular definition"});
   test.deepEqual(await valueof(zapp), {error: "RuntimeError: circular definition"});
-  test.deepEqual(await valueof(foo), {error: "RuntimeError: circular definition"}); // Variables that depend on cycles are themselves circular.
+  test.deepEqual(await valueof(foo), {error: "RuntimeError: bar could not be resolved"});
   foo.define("foo", [], () => "foo");
   await runtime._computing;
   test.equal(foo._reachable, true);


### PR DESCRIPTION
Rather than RuntimeError: circular definition, these are now RuntimeError: ${foo} could not be resolved.