### PR TITLE
More explicit type for special.

### DIFF
--- a/src/module.js
+++ b/src/module.js
@@ -13,7 +13,7 @@ export default function Module(runtime, special) {
     _special: {value: new Map([
       ["invalidation", variable_invalidation],
       ["visibility", variable_visibility],
-      ...(Symbol.iterator in special ? special : Object.entries(special))
+      ...special
     ])},
     _source: {value: null, writable: true}
   });

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -57,11 +57,11 @@ function runtime_module(define, observer = noop, special = {}) {
       this._init = null;
       return module;
     }
-    return new Module(this, special);
+    return new Module(this, Object.entries(special));
   }
   module = this._modules.get(define);
   if (module) return module;
-  this._init = module = new Module(this, special);
+  this._init = module = new Module(this, Object.entries(special));
   this._modules.set(define, module);
   try {
     define(this, observer);


### PR DESCRIPTION
This changes to *runtime*.module to require *special* to be an object, and new Module to require *special* to be an iterable of entries, rather than being ambiguous about what is expected.