### PR TITLE
Don’t allow an invalidated generator to start.

### DIFF
--- a/src/runtime.js
+++ b/src/runtime.js
@@ -233,6 +233,7 @@ function variable_compute(variable) {
     // If the value is a generator, then retrieve its first value,
     // and dispose of the generator if the variable is invalidated.
     if (generatorish(value)) {
+      if (variable._version !== version) return;
       (invalidation || variable_invalidator(variable)).then(variable_return(value));
       return variable_precompute(variable, version, promise, value);
     }

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -232,8 +232,10 @@ function variable_compute(variable) {
   }).then(function(value) {
     // If the value is a generator, then retrieve its first value,
     // and dispose of the generator if the variable is invalidated.
+    // Note that the cell may already have been invalidated here,
+    // in which case we need to terminate the generator immediately!
     if (generatorish(value)) {
-      if (variable._version !== version) return;
+      if (variable._version !== version) return void value.return();
       (invalidation || variable_invalidator(variable)).then(variable_return(value));
       return variable_precompute(variable, version, promise, value);
     }


### PR DESCRIPTION
Fixes #207.

By the time we realize that a cell’s value is generatorish, it could already have been invalidated. Since the invalidation promise is constructed lazily, this meant that the invalidation promise could be skipped (variable._invalidate was a noop when the cell was invalidated). So now we check that the cell hasn’t already been invalidated before starting the generator.