### PR TITLE
Adding a test for #220

### DIFF
--- a/test/variable/define-test.js
+++ b/test/variable/define-test.js
@@ -374,7 +374,7 @@ tape("variable.define correctly handles globals that throw", async test => {
   test.deepEqual(await valueof(foo), {error: "RuntimeError: oops could not be resolved"});
 });
 
-tape.only("variable.define allows other variables to begin computation before a generator may resume", async test => {
+tape("variable.define allows other variables to begin computation before a generator may resume", async test => {
   const runtime = new Runtime();
   const module = runtime.module();
   const main = runtime.module();


### PR DESCRIPTION
After much struggle, I was able to write a test that distinguishes the variable computation ordering on **master** from the ordering on **defer-recompute-test** ... but I'm not positive that it demonstrates that the change in ordering is what we desire it to be, so read carefully.

The meaningful difference between the two branches is on the line commented in the test case below. On the current **master**, at the time that the `gen` generator cell is first fulfilled, the actual generator has not resumed yet after its initial yield, and the value of `i` is still `1`.

On the **defer-recompute**  branch, at the time that the `gen` generator cell is first fulfilled, the generator has already resumed, and although the current value being yielded through the runtime is `1`, `i` already equals `2`.

Is this the behavior we want?