### PR TITLE
Don’t explicitly update outputs.

### DIFF
--- a/src/variable.js
+++ b/src/variable.js
@@ -103,9 +103,7 @@ function variable_defineImpl(name, inputs, definition) {
   else runtime._variables.add(this);
 
   // Did the variable’s name change? Time to patch references!
-  if (name == this._name && scope.get(name) === this) {
-    this._outputs.forEach(runtime._updates.add, runtime._updates);
-  } else {
+  if (name !== this._name || scope.get(name) !== this) {
     var error, found;
 
     if (this._name) { // Did this variable previously have a name?

--- a/test/variable/define-test.js
+++ b/test/variable/define-test.js
@@ -280,6 +280,21 @@ tape("variable.define allows a variable to be redefined", async test => {
   test.deepEqual(await valueof(bar), {value: 2});
 });
 
+tape("variable.define recomputes downstream values when a variable is renamed", async test => {
+  const runtime = new Runtime();
+  const main = runtime.module();
+  const foo = main.variable(true).define("foo", [], () => 1);
+  const bar = main.variable(true).define("bar", [], () => 2);
+  const baz = main.variable(true).define("baz", ["foo", "bar"], (foo, bar) => foo + bar);
+  test.deepEqual(await valueof(foo), {value: 1});
+  test.deepEqual(await valueof(bar), {value: 2});
+  test.deepEqual(await valueof(baz), {value: 3});
+  foo.define("quux", [], () => 10);
+  test.deepEqual(await valueof(foo), {value: 10});
+  test.deepEqual(await valueof(bar), {value: 2});
+  test.deepEqual(await valueof(baz), {error: "RuntimeError: foo is not defined"});
+});
+
 tape("variable.define ignores an asynchronous result from a redefined variable", async test => {
   const runtime = new Runtime();
   const main = runtime.module();


### PR DESCRIPTION
This shouldn’t be necessary as the transitive outputs of an updating variable are automatically computed if they are reachable. This passes the tests, but I’m curious if there’s a reason we were doing this.