### PR TITLE
Adding a test case for implicit-output-update

### DIFF
--- a/test/variable/define-test.js
+++ b/test/variable/define-test.js
@@ -280,6 +280,21 @@ tape("variable.define allows a variable to be redefined", async test => {
   test.deepEqual(await valueof(bar), {value: 2});
 });
 
+tape("variable.define recomputes downstream values when a variable is renamed", async test => {
+  const runtime = new Runtime();
+  const main = runtime.module();
+  const foo = main.variable(true).define("foo", [], () => 1);
+  const bar = main.variable(true).define("bar", [], () => 2);
+  const baz = main.variable(true).define("baz", ["foo", "bar"], (foo, bar) => foo + bar);
+  test.deepEqual(await valueof(foo), {value: 1});
+  test.deepEqual(await valueof(bar), {value: 2});
+  test.deepEqual(await valueof(baz), {value: 3});
+  foo.define("quux", [], () => 10);
+  test.deepEqual(await valueof(foo), {value: 10});
+  test.deepEqual(await valueof(bar), {value: 2});
+  test.deepEqual(await valueof(baz), {error: "RuntimeError: foo is not defined"});
+});
+
 tape("variable.define ignores an asynchronous result from a redefined variable", async test => {
   const runtime = new Runtime();
   const main = runtime.module();


### PR DESCRIPTION
... from my understanding of the change in https://github.com/observablehq/runtime/pull/239/files, this is the case that those lines of code intended to cover — looks like your PR continues to work just fine without them.