### PR TITLE
Clear dist before publishing.

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "scripts": {
     "test": "tape -r esm 'test/**/*-test.js'",
-    "prepublishOnly": "rollup -c",
+    "prepublishOnly": "rm -rf dist && rollup -c",
     "postpublish": "git push && git push --tags"
   },
   "husky": {


### PR DESCRIPTION
Looks like some cruft got [previously published](https://cdn.jsdelivr.net/npm/@observablehq/runtime@4.7.1/dist/). This should ensure a clean publish going forward.