### PR TITLE
defer generator resumption until after downstream cells

### DIFF
--- a/src/runtime.js
+++ b/src/runtime.js
@@ -206,10 +206,21 @@ function variable_compute(variable) {
   variable._invalidate();
   variable._invalidate = noop;
   variable._pending();
-  var value0 = variable._value,
-      version = ++variable._version,
-      invalidation = null,
-      promise = variable._promise = Promise.all(variable._inputs.map(variable_value)).then(function(inputs) {
+
+  const value0 = variable._value;
+  const version = ++variable._version;
+
+  // Lazily-constructed invalidation variable; only constructed if referenced as an input.
+  let invalidation = null;
+
+  // If the variable doesn’t have any inputs, we can optimize slightly.
+  const promise = variable._promise = (variable._inputs.length
+      ? Promise.all(variable._inputs.map(variable_value)).then(define)
+      : new Promise(resolve => resolve(variable._definition.call(value0))))
+    .then(generate);
+
+  // Compute the initial value of the variable.
+  function define(inputs) {
     if (variable._version !== version) return;
 
     // Replace any reference to invalidation with the promise, lazily.
@@ -227,20 +238,22 @@ function variable_compute(variable) {
       }
     }
 
-    // Compute the initial value of the variable.
     return variable._definition.apply(value0, inputs);
-  }).then(function(value) {
-    // If the value is a generator, then retrieve its first value,
-    // and dispose of the generator if the variable is invalidated.
-    // Note that the cell may already have been invalidated here,
-    // in which case we need to terminate the generator immediately!
+  }
+
+  // If the value is a generator, then retrieve its first value, and dispose of
+  // the generator if the variable is invalidated. Note that the cell may
+  // already have been invalidated here, in which case we need to terminate the
+  // generator immediately!
+  function generate(value) {
     if (generatorish(value)) {
       if (variable._version !== version) return void value.return();
       (invalidation || variable_invalidator(variable)).then(variable_return(value));
       return variable_generate(variable, version, value);
     }
     return value;
-  });
+  }
+
   promise.then(function(value) {
     if (variable._version !== version) return;
     variable._value = value;

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -255,9 +255,7 @@ function variable_compute(variable) {
 function variable_generate(variable, version, generator) {
   var runtime = variable._module._runtime;
   return (function recompute(first) {
-    return new Promise((resolve) => {
-      resolve(generator.next());
-    }).then(({done, value}) => {
+    return Promise.resolve(generator.next()).then(({done, value}) => {
       if (done) return;
       const promise = Promise.resolve(value);
       if (first) {

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -293,7 +293,7 @@ function variable_generate(variable, version, generator) {
 // relative depth of any downstream variable of the current generator. For now
 // we approximate by hard-coding a relatively shallow depth, which should at
 // least cover the common cases.
-function runtime_defer(task, depth = 6) {
+function runtime_defer(task, depth = 12) {
   queueMicrotask(depth > 1 ? () => runtime_defer(task, depth - 1) : task);
 }
 

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -266,6 +266,7 @@ function variable_generate(variable, version, generator) {
           runtime_defer(recompute);
         });
       } else {
+        variable._pending();
         variable._promise = promise;
         variable._outputs.forEach(runtime._updates.add, runtime._updates);
         const compute = runtime._compute();

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -281,7 +281,7 @@ function variable_generate(variable, version, generator) {
           variable._rejected(error);
         });
       }
-      return promise;
+      return value;
     });
   })(true);
 }

--- a/test/module/value-test.js
+++ b/test/module/value-test.js
@@ -37,6 +37,16 @@ tape("module.value(name) supports generators", async test => {
   test.deepEqual(await module.value("foo"), 3);
 });
 
+tape("module.value(name) supports async generators", async test => {
+  const runtime = new Runtime();
+  const module = runtime.module();
+  module.define("foo", [], async function*() { yield 1; yield 2; yield 3; });
+  test.deepEqual(await module.value("foo"), 1);
+  test.deepEqual(await module.value("foo"), 2);
+  test.deepEqual(await module.value("foo"), 3);
+  test.deepEqual(await module.value("foo"), 3);
+});
+
 tape("module.value(name) supports promises", async test => {
   const runtime = new Runtime();
   const module = runtime.module();

--- a/test/variable/define-test.js
+++ b/test/variable/define-test.js
@@ -388,3 +388,103 @@ tape("variable.define correctly handles globals that throw", async test => {
   const foo = module.variable(true).define(["oops"], oops => oops);
   test.deepEqual(await valueof(foo), {error: "RuntimeError: oops"});
 });
+
+tape("variable.define allows other variables to begin computation before a generator may resume", async test => {
+  const runtime = new Runtime();
+  const module = runtime.module();
+  const main = runtime.module();
+  let i = 0;
+  let genIteration = 0;
+  let valIteration = 0;
+  const onGenFulfilled = value => {
+    if (genIteration === 0) {
+      test.equals(valIteration, 0);
+      test.equals(value, 1);
+      test.equals(i, 1);
+    } else if (genIteration === 1) {
+      test.equals(valIteration, 0);
+      test.equals(value, 2);
+      test.equals(i, 2);
+    } else if (genIteration === 2) {
+      test.equals(valIteration, 1);
+      test.equals(value, 3);
+      test.equals(i, 3);
+    } else {
+      test.fail();
+    }
+    genIteration++;
+  };
+  const onValFulfilled = value => {
+    if (valIteration === 0) {
+      test.equals(genIteration, 2);
+      test.equals(value, 1);
+      test.equals(i, 2);
+    }
+    else if (valIteration === 1) {
+      test.equals(genIteration, 3);
+      test.equals(value, 2);
+      test.equals(i, 3);
+    }
+    else if (valIteration === 2) {
+      test.equals(genIteration, 3);
+      test.equals(value, 3);
+      test.equals(i, 3);
+    } else {
+      test.fail();
+    }
+    valIteration++;
+  };
+  const gen = module.variable({fulfilled: onGenFulfilled}).define("gen", [], function*() {
+    i++;
+    yield i;
+    i++;
+    yield i;
+    i++;
+    yield i;
+  });
+  main.variable().import("gen", module);
+  const val = main.variable({fulfilled: onValFulfilled}).define("val", ["gen"], i => i);
+  test.equals(await gen._promise, undefined, "gen cell undefined");
+  test.equals(await val._promise, undefined, "val cell undefined");
+  await runtime._compute();
+  test.equals(await gen._promise, 1, "gen cell 1");
+  test.equals(await val._promise, 1, "val cell 1");
+  await runtime._compute();
+  test.equals(await gen._promise, 2, "gen cell 2");
+  test.equals(await val._promise, 2, "val cell 2");
+  await runtime._compute();
+  test.equals(await gen._promise, 3, "gen cell 3");
+  test.equals(await val._promise, 3, "val cell 3");
+});
+
+tape("variable.define allows other variables to begin computation before a generator may resume", async test => {
+  const runtime = new Runtime();
+  const main = runtime.module();
+  let i = 0;
+  let j = 0;
+  const gen = main.variable().define("gen", [], function*() {
+    i++;
+    yield i;
+    i++;
+    yield i;
+    i++;
+    yield i;
+  });
+  const val = main.variable(true).define("val", ["gen"], gen => {
+    j++;
+    test.equals(gen, j, "gen = j");
+    test.equals(gen, i, "gen = i");
+    return gen;
+  });
+  test.equals(await gen._promise, undefined, "gen = undefined");
+  test.equals(await val._promise, undefined, "val = undefined");
+  await runtime._compute();
+  test.equals(await gen._promise, 1, "gen cell 1");
+  test.equals(await val._promise, 1, "val cell 1");
+  await runtime._compute();
+  test.equals(await gen._promise, 2, "gen cell 2");
+  test.equals(await val._promise, 2, "val cell 2");
+  await runtime._compute();
+  test.equals(await gen._promise, 3, "gen cell 3");
+  test.equals(await val._promise, 3, "val cell 3");
+});

--- a/test/variable/define-test.js
+++ b/test/variable/define-test.js
@@ -402,11 +402,11 @@ tape("variable.define allows other variables to begin computation before a gener
       test.equals(value, 1);
       test.equals(i, 1);
     } else if (genIteration === 1) {
-      test.equals(valIteration, 0);
+      test.equals(valIteration, 1);
       test.equals(value, 2);
       test.equals(i, 2);
     } else if (genIteration === 2) {
-      test.equals(valIteration, 1);
+      test.equals(valIteration, 2);
       test.equals(value, 3);
       test.equals(i, 3);
     } else {
@@ -416,16 +416,14 @@ tape("variable.define allows other variables to begin computation before a gener
   };
   const onValFulfilled = value => {
     if (valIteration === 0) {
-      test.equals(genIteration, 2);
+      test.equals(genIteration, 1);
       test.equals(value, 1);
-      test.equals(i, 2);
-    }
-    else if (valIteration === 1) {
-      test.equals(genIteration, 3);
+      test.equals(i, 1);
+    } else if (valIteration === 1) {
+      test.equals(genIteration, 2);
       test.equals(value, 2);
-      test.equals(i, 3);
-    }
-    else if (valIteration === 2) {
+      test.equals(i, 2);
+    } else if (valIteration === 2) {
       test.equals(genIteration, 3);
       test.equals(value, 3);
       test.equals(i, 3);


### PR DESCRIPTION
This has two effects:

1. When a (non-asynchronous) generator yields a value (even if the value is a promise), that value immediately becomes the cell’s apparent value for the rest of the notebook. This means that another cell referencing this value will begin computing (i.e., show a gray border indicating active computation) and a new cell referencing this value will wait until the promise resolves rather than seeing the stale value.

2. The generator will now always resume as part of the same event loop, but after (though see caveat) any downstream synchronous cells have a chance to compute. Previously, we did synchronous resumption only for the first yielded value, but possibly before downstream cells had a chance to run; and on subsequent yields we deferred resumption until the next animation frame, which could lead to skipped frames.

See this (internal only) notebook for more explanation: https://observablehq.com/d/e6fff2ad18deec3c

Ref. https://github.com/observablehq/feedback/issues/243