### PR TITLE
defer generator resumption until start of frame

### DIFF
--- a/src/runtime.js
+++ b/src/runtime.js
@@ -293,7 +293,7 @@ function variable_generate(variable, version, generator) {
   // to undefined if the generator is done.
   function compute(onfulfilled) {
     return new Promise(resolve => resolve(generator.next())).then(({done, value}) => {
-      return done ? undefined : (Promise.resolve(value).then(onfulfilled), value);
+      return done ? undefined : (value = Promise.resolve(value), value.then(onfulfilled), value);
     });
   }
 

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -302,19 +302,15 @@ function variable_generate(variable, version, generator) {
         }
         return value;
       });
-    }, first ? undefined : (error) => {
-      // The variable’s promise isn’t normally set until the generator yields a
-      // value; here generator.next threw an error before yielding.
-      variable._promise = promise;
-      throw error;
     });
     if (!first) {
       promise.catch((error) => {
         if (variable._version !== version) return;
-        // If generator.next threw an error (see above), or if the resulting
-        // value was a rejected promise, we’ll end up here.
         variable._value = undefined;
+        variable._promise = promise;
+        variable._outputs.forEach(runtime._updates.add, runtime._updates);
         variable._rejected(error);
+        runtime._compute();
       });
     }
     return promise;

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -309,10 +309,17 @@ function variable_generate(variable, version, generator) {
         });
       }
       return value;
+    }, first ? undefined : (error) => {
+      // The variable’s promise isn’t normally set until the generator yields a
+      // value; here generator.next threw an error before yielding.
+      variable._promise = promise;
+      throw error;
     });
     if (!first) {
       promise.catch((error) => {
         if (variable._version !== version) return;
+        // If generator.next threw an error (see above), or if the resulting
+        // value was a rejected promise, we’ll end up here.
         variable._value = undefined;
         variable._rejected(error);
       });

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -97,7 +97,7 @@ async function runtime_computeNow() {
   // can update (if synchronous) before computing downstream variables.
   if (precomputes.length) {
     this._precomputes = [];
-    for (const callback of precomputes) try { callback(); } catch {}
+    for (const callback of precomputes) callback();
     await runtime_defer(3);
   }
 

--- a/test/module/value-test.js
+++ b/test/module/value-test.js
@@ -37,6 +37,16 @@ tape("module.value(name) supports generators", async test => {
   test.deepEqual(await module.value("foo"), 3);
 });
 
+tape("module.value(name) supports async generators", async test => {
+  const runtime = new Runtime();
+  const module = runtime.module();
+  module.define("foo", [], async function*() { yield 1; yield 2; yield 3; });
+  test.deepEqual(await module.value("foo"), 1);
+  test.deepEqual(await module.value("foo"), 2);
+  test.deepEqual(await module.value("foo"), 3);
+  test.deepEqual(await module.value("foo"), 3);
+});
+
 tape("module.value(name) supports promises", async test => {
   const runtime = new Runtime();
   const module = runtime.module();

--- a/test/module/value-test.js
+++ b/test/module/value-test.js
@@ -41,9 +41,18 @@ tape("module.value(name) supports generators that throw", async test => {
   const runtime = new Runtime();
   const module = runtime.module();
   module.define("foo", [], function*() { yield 1; throw new Error("fooed"); });
-  test.deepEqual(await module.value("foo"), 1);
+  module.define("bar", ["foo"], foo => foo);
+  const [foo1, bar1] = await Promise.all([module.value("foo"), module.value("bar")]);
+  test.deepEqual(foo1, 1);
+  test.deepEqual(bar1, 1);
   try {
     await module.value("foo");
+    test.fail();
+  } catch (error) {
+    test.deepEqual(error.message, "fooed");
+  }
+  try {
+    await module.value("bar");
     test.fail();
   } catch (error) {
     test.deepEqual(error.message, "fooed");

--- a/test/module/value-test.js
+++ b/test/module/value-test.js
@@ -37,6 +37,19 @@ tape("module.value(name) supports generators", async test => {
   test.deepEqual(await module.value("foo"), 3);
 });
 
+tape("module.value(name) supports generators that throw", async test => {
+  const runtime = new Runtime();
+  const module = runtime.module();
+  module.define("foo", [], function*() { yield 1; throw new Error("fooed"); });
+  test.deepEqual(await module.value("foo"), 1);
+  try {
+    await module.value("foo");
+    test.fail();
+  } catch (error) {
+    test.deepEqual(error.message, "fooed");
+  }
+});
+
 tape("module.value(name) supports async generators", async test => {
   const runtime = new Runtime();
   const module = runtime.module();


### PR DESCRIPTION
Generators now resume at the _start_ of the next animation frame, but before any other cells compute. Previously, generators resumed immediately (in a microtask) on the first value, and then (roughly) concurrently with other variables on the next frame for subsequent values. This new approach provides more predictable and consistent semantics.

For example, this now does a nice fade-in:

```js
{
  const div = htl.html`<div style="background-color: white; transition: background-color 1000ms ease;">hello`;
  yield div;
  div.style.backgroundColor = "red";
}
```

See this (internal only) notebook for more explanation: https://observablehq.com/d/e6fff2ad18deec3c

Ref. https://github.com/observablehq/feedback/issues/243

Previously #318 #220 #108.