### PR TITLE
use setTimeout instead of setImmediate (for better compatibility with Deno)

### DIFF
--- a/src/runtime.js
+++ b/src/runtime.js
@@ -6,7 +6,7 @@ import Module from "./module";
 import noop from "./noop";
 import Variable, {TYPE_IMPLICIT, no_observer} from "./variable";
 
-const frame = typeof requestAnimationFrame === "function" ? requestAnimationFrame : setImmediate;
+const frame = typeof requestAnimationFrame === "function" ? requestAnimationFrame : func => setTimeout(func, 0);
 
 export var variable_invalidation = {};
 export var variable_visibility = {};


### PR DESCRIPTION
When running in Deno, I need to execute notebooks like this:

~~~js
window.setImmediate = func => setTimeout(func, 0);
const { Runtime } = await import(
  "https://cdn.jsdelivr.net/npm/@observablehq/runtime@4/dist/runtime.js"
);
~~~

This requires me to set a mock / pollyfill of the setImmediate function, and then use a dynamic import for the runtime module. setTimeout should serve the same purpose and work in a wider variety of environments.