### PR TITLE
don’t expose stale values

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -19,7 +19,13 @@ function config(output) {
             "SQLiteDatabaseClient",
             "Workbook",
             "ZipArchive",
-            "ZipArchiveEntry"
+            "ZipArchiveEntry",
+            "Runtime",
+            "RuntimeError",
+            "Variable",
+            "Module",
+            "Library",
+            "Inspector",
           ]
         }
       })

--- a/src/module.js
+++ b/src/module.js
@@ -4,7 +4,7 @@ import {RuntimeError} from "./errors";
 import identity from "./identity";
 import rethrow from "./rethrow";
 import {variable_invalidation, variable_visibility} from "./runtime";
-import Variable, {TYPE_DUPLICATE, TYPE_IMPLICIT, TYPE_NORMAL, no_observer} from "./variable";
+import Variable, {TYPE_DUPLICATE, TYPE_IMPLICIT, TYPE_NORMAL, no_observer, variable_stale} from "./variable";
 
 export default function Module(runtime, builtins = []) {
   Object.defineProperties(this, {
@@ -65,12 +65,8 @@ async function module_value(name) {
 // If the variable is redefined before its value resolves, try again.
 async function module_revalue(runtime, variable) {
   await runtime._compute();
-  const version = variable._version;
-  return variable._promise.then((value) => {
-    if (variable._version !== version) return module_revalue(runtime, variable);
-    return value;
-  }, (error) => {
-    if (variable._version !== version) return module_revalue(runtime, variable);
+  return variable._promise.catch((error) => {
+    if (error === variable_stale) return module_revalue(runtime, variable);
     throw error;
   });
 }

--- a/src/module.js
+++ b/src/module.js
@@ -65,10 +65,12 @@ async function module_value(name) {
 // If the variable is redefined before its value resolves, try again.
 async function module_revalue(runtime, variable) {
   await runtime._compute();
-  return variable._promise.catch((error) => {
+  try {
+    return await variable._promise;
+  } catch (error) {
     if (error === variable_stale) return module_revalue(runtime, variable);
     throw error;
-  });
+  }
 }
 
 function module_derive(injects, injectModule) {

--- a/src/variable.js
+++ b/src/variable.js
@@ -167,6 +167,7 @@ function variable_defineImpl(name, inputs, definition) {
     this._name = name;
   }
 
+  ++this._version;
   runtime._updates.add(this);
   runtime._compute();
   return this;

--- a/src/variable.js
+++ b/src/variable.js
@@ -55,8 +55,13 @@ function variable_undefined() {
   throw variable_undefined;
 }
 
+export function variable_stale() {
+  throw variable_stale;
+}
+
 function variable_rejector(variable) {
   return function(error) {
+    if (error === variable_stale) throw error;
     if (error === variable_undefined) throw new RuntimeError(variable._name + " is not defined", variable._name);
     if (error instanceof Error && error.message) throw new RuntimeError(error.message, variable._name);
     throw new RuntimeError(variable._name + " could not be resolved", variable._name);
@@ -167,7 +172,11 @@ function variable_defineImpl(name, inputs, definition) {
     this._name = name;
   }
 
-  ++this._version;
+  // If this redefined variable was previously evaluated, invalidate it. (If the
+  // variable was never evaluated, then the invalidated value could never have
+  // been exposed and we can avoid this extra work.)
+  if (this._version > 0) ++this._version;
+
   runtime._updates.add(this);
   runtime._compute();
   return this;


### PR DESCRIPTION
If a variable is redefined before its value resolves, we shouldn’t expose it via *module*.value. Instead, we should retry to get the variable’s new value.

(It’s possible that this could continue forever if the variable is continuously redefined—*e.g.*, it is both slow asynchronous and downstream from a fast generator—but this is consistent with what you’d in a notebook and hence I feel correct.)

(It’s already the case that observers do not report these invalidated values when fulfilling or rejecting.)