### PR TITLE
free after value resolution

### DIFF
--- a/src/module.js
+++ b/src/module.js
@@ -56,10 +56,15 @@ async function module_value(name) {
   var v = this._scope.get(name);
   if (!v) throw new RuntimeError(name + " is not defined");
   if (v._observer === no_observer) {
-    v._observer = true;
-    this._runtime._dirty.add(v);
+    v = this.variable(true).define([name], identity);
+    try {
+      return await module_revalue(this._runtime, v);
+    } finally {
+      v.delete();
+    }
+  } else {
+    return module_revalue(this._runtime, v);
   }
-  return module_revalue(this._runtime, v);
 }
 
 // If the variable is redefined before its value resolves, try again.


### PR DESCRIPTION
Fixes #334. Rather than setting the variable._observer to true (and never restoring the original no_observer), create a new variable that takes the named variable as input, and observe that. That way we can delete the variable when we’re done.