### PR TITLE
handle stale generator

### DIFF
--- a/src/runtime.js
+++ b/src/runtime.js
@@ -312,8 +312,7 @@ function variable_generate(variable, version, generator) {
       return value;
     });
     promise.catch((error) => {
-      if (error === variable_stale) throw error;
-      if (variable._version !== version) throw variable_stale;
+      if (error === variable_stale || variable._version !== version) return;
       postcompute(undefined, promise);
       variable._rejected(error);
     });


### PR DESCRIPTION
Errors in this promise were unhandled, so we shouldn’t rethrow `variable_stale` here; we should instead simply `return` because the generator has been terminated due to it becoming stale.

Fixes https://github.com/observablehq/feedback/issues/465.