### PR TITLE
support lazy imports

### DIFF
--- a/src/module.js
+++ b/src/module.js
@@ -111,7 +111,7 @@ function module_derive(injects, injectModule) {
   for (const module of modules) {
     for (const variable of module._scope.values()) {
       if (variable._definition === identity) { // import
-        if (derive._scope.has(variable._name)) continue; // overridden by injection
+        if (module === this && derive._scope.has(variable._name)) continue; // overridden by injection
         const importedModule = variable._inputs[0]._module;
         if (importedModule._source) alias(importedModule);
       }

--- a/src/module.js
+++ b/src/module.js
@@ -1,9 +1,8 @@
-import {forEach} from "./array";
 import constant from "./constant";
 import {RuntimeError} from "./errors";
 import identity from "./identity";
 import rethrow from "./rethrow";
-import {variable_invalidation, variable_visibility} from "./runtime";
+import {variable_variable, variable_invalidation, variable_visibility} from "./runtime";
 import Variable, {TYPE_DUPLICATE, TYPE_IMPLICIT, TYPE_NORMAL, no_observer, variable_stale} from "./variable";
 
 export default function Module(runtime, builtins = []) {
@@ -11,6 +10,7 @@ export default function Module(runtime, builtins = []) {
     _runtime: {value: runtime},
     _scope: {value: new Map},
     _builtins: {value: new Map([
+      ["@variable", variable_variable],
       ["invalidation", variable_invalidation],
       ["visibility", variable_visibility],
       ...builtins
@@ -20,7 +20,6 @@ export default function Module(runtime, builtins = []) {
 }
 
 Object.defineProperties(Module.prototype, {
-  _copy: {value: module_copy, writable: true, configurable: true},
   _resolve: {value: module_resolve, writable: true, configurable: true},
   redefine: {value: module_redefine, writable: true, configurable: true},
   define: {value: module_define, writable: true, configurable: true},
@@ -79,51 +78,62 @@ async function module_revalue(runtime, variable) {
 }
 
 function module_derive(injects, injectModule) {
-  var copy = new Module(this._runtime, this._builtins);
-  copy._source = this;
-  forEach.call(injects, function(inject) {
-    if (typeof inject !== "object") inject = {name: inject + ""};
-    if (inject.alias == null) inject.alias = inject.name;
-    copy.import(inject.name, inject.alias, injectModule);
-  });
-  Promise.resolve().then(() => {
-    const modules = new Set([this]);
-    for (const module of modules) {
-      for (const variable of module._scope.values()) {
-        if (variable._definition === identity) { // import
-          const module = variable._inputs[0]._module;
-          const source = module._source || module;
-          if (source === this) { // circular import-with!
-            console.warn("circular module definition; ignoring"); // eslint-disable-line no-console
-            return;
-          }
-          modules.add(source);
-        }
+  const map = new Map();
+  const modules = new Set();
+  const copies = [];
+
+  // Given a module, derives an alias of that module with an initially-empty
+  // definition. The variables will be copied later in a second pass below.
+  function alias(source) {
+    let target = map.get(source);
+    if (target) return target;
+    target = new Module(source._runtime, source._builtins);
+    target._source = source;
+    map.set(source, target);
+    copies.push([target, source]);
+    modules.add(source);
+    return target;
+  }
+
+  // Inject the given variables as reverse imports into the derived module.
+  const derive = alias(this);
+  for (const inject of injects) {
+    const {alias, name} = typeof inject === "object" ? inject : {name: inject};
+    derive.import(name, alias == null ? name : alias, injectModule);
+  }
+
+  // Iterate over all the variables (currently) in this module. If any
+  // represents an import-with (i.e., an import of a module with a _source), the
+  // transitive import-with must be copied, too, as direct injections may affect
+  // transitive injections. Note that an import-with can only be created with
+  // module.derive and hence it’s not possible for an import-with to be added
+  // later; therefore we only need to apply this check once, now.
+  for (const module of modules) {
+    for (const variable of module._scope.values()) {
+      if (variable._definition === identity) { // import
+        if (derive._scope.has(variable._name)) continue; // overridden by injection
+        const importedModule = variable._inputs[0]._module;
+        if (importedModule._source) alias(importedModule);
       }
     }
-    this._copy(copy, new Map);
-  });
-  return copy;
-}
+  }
 
-function module_copy(copy, map) {
-  copy._source = this;
-  map.set(this, copy);
-  for (const [name, source] of this._scope) {
-    var target = copy._scope.get(name);
-    if (target && target._type === TYPE_NORMAL) continue; // injection
-    if (source._definition === identity) { // import
-      var sourceInput = source._inputs[0],
-          sourceModule = sourceInput._module;
-      copy.import(sourceInput._name, name, map.get(sourceModule)
-        || (sourceModule._source
-           ? sourceModule._copy(new Module(copy._runtime, copy._builtins), map) // import-with
-           : sourceModule));
-    } else {
-      copy.define(name, source._inputs.map(variable_name), source._definition);
+  // Finally, with the modules resolved, copy the variable definitions.
+  for (const [target, source] of copies) {
+    for (const [name, sourceVariable] of source._scope) {
+      const targetVariable = target._scope.get(name);
+      if (targetVariable && targetVariable._type !== TYPE_IMPLICIT) continue; // preserve injection
+      if (sourceVariable._definition === identity) { // import
+        const sourceInput = sourceVariable._inputs[0];
+        const sourceModule = sourceInput._module;
+        target.import(sourceInput._name, name, map.get(sourceModule) || sourceModule);
+      } else { // non-import
+        target.define(name, sourceVariable._inputs.map(variable_name), sourceVariable._definition);
+      }
     }
   }
-  return copy;
+
+  return derive;
 }
 
 function module_resolve(name) {

--- a/src/module.js
+++ b/src/module.js
@@ -109,9 +109,9 @@ function module_derive(injects, injectModule) {
   // module.derive and hence it’s not possible for an import-with to be added
   // later; therefore we only need to apply this check once, now.
   for (const module of modules) {
-    for (const variable of module._scope.values()) {
+    for (const [name, variable] of module._scope) {
       if (variable._definition === identity) { // import
-        if (module === this && derive._scope.has(variable._name)) continue; // overridden by injection
+        if (module === this && derive._scope.has(name)) continue; // overridden by injection
         const importedModule = variable._inputs[0]._module;
         if (importedModule._source) alias(importedModule);
       }

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -10,6 +10,7 @@ const frame = typeof requestAnimationFrame === "function" ? requestAnimationFram
   : typeof setImmediate === "function" ? setImmediate
   : f => setTimeout(f, 0);
 
+export var variable_variable = {};
 export var variable_invalidation = {};
 export var variable_visibility = {};
 
@@ -255,6 +256,10 @@ function variable_compute(variable) {
         case variable_visibility: {
           if (!invalidation) invalidation = variable_invalidator(variable);
           inputs[i] = variable_intersector(invalidation, variable);
+          break;
+        }
+        case variable_variable: {
+          inputs[i] = variable;
           break;
         }
       }

--- a/test/variable/derive-test.js
+++ b/test/variable/derive-test.js
@@ -1,6 +1,7 @@
 import {Runtime} from "../../src/";
+import identity from "../../src/identity";
 import tape from "../tape";
-import valueof from "./valueof";
+import valueof, {delay, promiseInspector, sleep} from "./valueof";
 
 tape("module.derive(overrides, module) injects variables into a copied module", async test => {
   const runtime = new Runtime();
@@ -32,18 +33,32 @@ tape("module.derive(…) copies module-specific builtins", async test => {
 
 tape("module.derive(…) can inject into modules that inject into modules", async test => {
   const runtime = new Runtime();
+
+  // Module A
+  // a = 1
+  // b = 2
+  // c = a + b
   const A = runtime.module();
   A.define("a", 1);
   A.define("b", 2);
   A.define("c", ["a", "b"], (a, b) => a + b);
+
+  // Module B
+  // d = 3
+  // import {c as e} with {d as b} from "A"
   const B = runtime.module();
   B.define("d", 3);
   const BA = A.derive([{name: "d", alias: "b"}], B);
   B.import("c", "e", BA);
+
+  // Module C
+  // f = 4
+  // import {e as g} with {f as d} from "B"
   const C = runtime.module();
   C.define("f", 4);
   const CB = B.derive([{name: "f", alias: "d"}], C);
   const g = C.variable(true).import("e", "g", CB);
+
   test.deepEqual(await valueof(g), {value: 5});
   test.strictEqual(g._module, C);
   test.strictEqual(g._inputs[0]._module, CB);
@@ -53,18 +68,75 @@ tape("module.derive(…) can inject into modules that inject into modules", asyn
   test.strictEqual(BA._source, A);
 });
 
-tape("module.derive(…) does not copy non-injected modules", async test => {
+tape("module.derive(…) can inject into modules that inject into modules that inject into modules", async test => {
   const runtime = new Runtime();
+
+  // Module A
+  // a = 1
+  // b = 2
+  // c = a + b
   const A = runtime.module();
   A.define("a", 1);
   A.define("b", 2);
   A.define("c", ["a", "b"], (a, b) => a + b);
+
+  // Module B
+  // d = 3
+  // import {c as e} with {d as b} from "A"
+  const B = runtime.module();
+  B.define("d", 3);
+  const BA = A.derive([{name: "d", alias: "b"}], B);
+  B.import("c", "e", BA);
+
+  // Module C
+  // f = 4
+  // import {e as g} with {f as d} from "B"
+  const C = runtime.module();
+  C.define("f", 4);
+  const CB = B.derive([{name: "f", alias: "d"}], C);
+  C.import("e", "g", CB);
+
+  // Module D
+  // h = 5
+  // import {g as i} with {h as f} from "C"
+  const D = runtime.module();
+  D.define("h", 5);
+  const DC = C.derive([{name: "h", alias: "f"}], D);
+  const i = D.variable(true).import("g", "i", DC);
+
+  test.deepEqual(await valueof(i), {value: 6});
+  test.strictEqual(i._module, D);
+  test.strictEqual(i._inputs[0]._module, DC);
+  test.strictEqual(i._inputs[0]._module._source, C);
+  test.strictEqual(i._inputs[0]._inputs[0]._module._source, CB);
+  test.strictEqual(i._inputs[0]._inputs[0]._module._source._source, B);
+});
+
+tape("module.derive(…) does not copy non-injected modules", async test => {
+  const runtime = new Runtime();
+
+  // Module A
+  // a = 1
+  // b = 2
+  // c = a + b
+  const A = runtime.module();
+  A.define("a", 1);
+  A.define("b", 2);
+  A.define("c", ["a", "b"], (a, b) => a + b);
+
+  // Module B
+  // import {c as e} from "A"
   const B = runtime.module();
   B.import("c", "e", A);
+
+  // Module C
+  // f = 4
+  // import {e as g} with {f as d} from "B"
   const C = runtime.module();
   C.define("f", 4);
   const CB = B.derive([{name: "f", alias: "d"}], C);
   const g = C.variable(true).import("e", "g", CB);
+
   test.deepEqual(await valueof(g), {value: 3});
   test.strictEqual(g._module, C);
   test.strictEqual(g._inputs[0]._module, CB);
@@ -85,4 +157,134 @@ tape("module.derive(…) does not copy non-injected modules, again", async test 
   const {value: v2} = await valueof(a2);
   test.deepEqual(v1, {});
   test.strictEqual(v1, v2);
+});
+
+tape("module.derive() supports lazy import-with", async test => {
+  let resolve2, promise2 = new Promise((resolve) => resolve2 = resolve);
+
+  function define1(runtime, observer) {
+    const main = runtime.module();
+    main.define("module 1", ["@variable"], async (v) => runtime.module(await promise2).derive([{name: "b"}], v._module));
+    main.define("c", ["module 1", "@variable"], (_, v) => v.import("c", _));
+    main.variable(observer("b")).define("b", [], () => 3);
+    main.variable(observer("imported c")).define("imported c", ["c"], c => c);
+    return main;
+  }
+
+  function define2(runtime, observer) {
+    const main = runtime.module();
+    main.variable(observer("a")).define("a", [], () => 1);
+    main.variable(observer("b")).define("b", [], () => 2);
+    main.variable(observer("c")).define("c", ["a", "b"], (a, b) => a + b);
+    return main;
+  }
+
+  const runtime = new Runtime();
+  const inspectorC = promiseInspector();
+  runtime.module(define1, name => {
+    if (name === "imported c") {
+      return inspectorC;
+    }
+  });
+
+  await sleep();
+  resolve2(define2);
+  test.deepEqual(await inspectorC, 4);
+});
+
+tape("module.derive() supports lazy transitive import-with", async test => {
+  let resolve2, promise2 = new Promise((resolve) => resolve2 = resolve);
+  let resolve3, promise3 = new Promise((resolve) => resolve3 = resolve);
+  let module2_1;
+  let module3_2;
+  let variableC_1;
+
+  // Module 1
+  // b = 4
+  // imported c = c
+  // import {c} with {b} from "2"
+  function define1(runtime, observer) {
+    const main = runtime.module();
+    main.define("module 2", ["@variable"], async (v) => (module2_1 = runtime.module(await promise2).derive([{name: "b"}], v._module)));
+    variableC_1 = main.define("c", ["module 2", "@variable"], (_, v) => v.import("c", _));
+    main.variable(observer("b")).define("b", [], () => 4);
+    main.variable(observer("imported c")).define("imported c", ["c"], c => c);
+    return main;
+  }
+
+  // Module 2
+  // b = 3
+  // c
+  // import {c} with {b} from "3"
+  function define2(runtime, observer) {
+    const main = runtime.module();
+    main.define("module 3", ["@variable"], async (v) => (module3_2 = runtime.module(await promise3).derive([{name: "b"}], v._module)));
+    main.define("c", ["module 3", "@variable"], (_, v) => v.import("c", _));
+    main.variable(observer("b")).define("b", [], () => 3);
+    main.variable(observer()).define(["c"], c => c);
+    return main;
+  }
+
+  // Module 3
+  // a = 1
+  // b = 2
+  // c = a + b
+  function define3(runtime, observer) {
+    const main = runtime.module();
+    main.variable(observer("a")).define("a", [], () => 1);
+    main.variable(observer("b")).define("b", [], () => 2);
+    main.variable(observer("c")).define("c", ["a", "b"], (a, b) => a + b);
+    return main;
+  }
+
+  const runtime = new Runtime();
+  const inspectorC = promiseInspector();
+  runtime.module(define1, name => {
+    if (name === "imported c") {
+      return inspectorC;
+    }
+  });
+
+  // Initially c in module 1 is not an import; it’s a placeholder that depends
+  // on an internal variable called “module 2”. Also, only one module yet
+  // exists, because module 2 has not yet loaded.
+  await sleep();
+  const module1 = runtime.module(define1);
+  const c1 = module1._scope.get("c");
+  test.strictEqual(c1, variableC_1);
+  test.deepEqual(c1._inputs.map(i => i._name), ["module 2", "@variable"]);
+  test.strictEqual(runtime._modules.size, 1);
+
+  // After module 2 loads, the variable c in module 1 has been redefined; it is
+  // now an import of c from a derived copy of module 2, module 2'. In addition,
+  // the variable b in module 2' is now an import from module 1.
+  resolve2(define2);
+  await sleep();
+  const module2 = runtime.module(define2);
+  test.deepEqual(c1._inputs.map(i => i._name), ["c"]);
+  test.strictEqual(c1._definition, identity);
+  test.strictEqual(c1._inputs[0]._module, module2_1);
+  test.strictEqual(module2_1._source, module2);
+  test.strictEqual(runtime._modules.size, 2);
+  const b2_1 = module2_1._scope.get("b");
+  test.deepEqual(b2_1._inputs.map(i => i._name), ["b"]);
+  test.deepEqual(b2_1._definition, identity);
+  test.deepEqual(b2_1._inputs[0]._module, module1);
+
+  // After module 3 loads, the variable c in module 2' has been redefined; it is
+  // now an import of c from a derived copy of module 3, module 3'. In addition,
+  // the variable b in module 3' is now an import from module 2'.
+  resolve3(define3);
+  await sleep();
+  const module3 = runtime.module(define3);
+  const c2_1 = module2_1._scope.get("c");
+  test.strictEqual(c2_1._module, module2_1);
+  test.strictEqual(c2_1._definition, identity);
+  test.strictEqual(c2_1._inputs[0]._module, module3_2);
+  test.strictEqual(module3_2._source, module3);
+  const b3_2 = module3_2._scope.get("b");
+  test.deepEqual(b3_2._inputs.map(i => i._name), ["b"]);
+  test.deepEqual(b3_2._definition, identity);
+  test.deepEqual(b3_2._inputs[0]._module, module2_1);
+  test.deepEqual(await inspectorC, 5);
 });

--- a/test/variable/import-test.js
+++ b/test/variable/import-test.js
@@ -1,6 +1,6 @@
 import {Runtime} from "../../src/";
 import tape from "../tape";
-import valueof from "./valueof";
+import valueof, {promiseInspector, sleep} from "./valueof";
 
 tape("variable.import(name, module) imports a variable from another module", async test => {
   const runtime = new Runtime();
@@ -72,85 +72,86 @@ tape("variable.import() fails when importing creates a circular reference", asyn
 });
 
 tape(
-  "variable.import() fails to resolve variables derived from a direct circular import with",
+  "variable.import() allows direct circular import-with if the resulting variables are not circular",
   async test => {
     const runtime = new Runtime();
     let a1, b1, a2, b2;
 
+    // Module 1
+    // a = 1
+    // b
+    // import {b} with {a} from "2"
     function define1() {
       const main = runtime.module();
-      a1 = main.variable(true).define("a", function() {
-        return 1;
-      });
-      b1 = main.variable(true).define(["b"], function(b) {
-        return b;
-      });
+      a1 = main.variable(true).define("a", () => 1);
+      b1 = main.variable(true).define(["b"], (b) => b);
       const child1 = runtime.module(define2).derive(["a"], main);
       main.import("b", child1);
       return main;
     }
 
+    // Module 2
+    // b = 2
+    // a
+    // import {a} with {b} from "1"
     function define2() {
       const main = runtime.module();
-      b2 = main.variable(true).define("b", function() {
-        return 2;
-      });
-      a2 = main.variable(true).define(["a"], function(a) {
-        return a;
-      });
+      b2 = main.variable(true).define("b", () => 2);
+      a2 = main.variable(true).define(["a"], (a) => a);
       const child1 = runtime.module(define1).derive(["b"], main);
       main.import("a", child1);
       return main;
     }
+
     define1();
 
     test.deepEqual(await valueof(a1), {value: 1});
-    test.deepEqual(await valueof(b1), {error: 'RuntimeError: b is not defined'});
-    test.deepEqual(await valueof(a2), {error: 'RuntimeError: a is not defined'});
+    test.deepEqual(await valueof(b1), {value: 2});
+    test.deepEqual(await valueof(a2), {value: 1});
     test.deepEqual(await valueof(b2), {value: 2});
   }
 );
 
 tape(
-  "variable.import() also fails to resolve variables derived from an indirectly circular import with",
+  "variable.import() allows indirect circular import-with if the resulting variables are not circular",
   async test => {
     const runtime = new Runtime();
     let a, b, c, importA, importB, importC;
 
+    // Module 1
+    // a = 1
+    // c
+    // import {c} with {a} from "3"
     function define1() {
       const main = runtime.module();
-      a = main.variable(true).define("a", function() {
-        return 1;
-      });
-      importC = main.variable(true).define(["c"], function(c) {
-        return c;
-      });
+      a = main.variable(true).define("a", () => 1);
+      importC = main.variable(true).define(["c"], (c) => c);
       const child3 = runtime.module(define3).derive(["a"], main);
       main.import("c", child3);
       return main;
     }
 
+    // Module 2
+    // b = 2
+    // a
+    // import {a} with {b} from "1"
     function define2() {
       const main = runtime.module();
-      b = main.variable(true).define("b", function() {
-        return 2;
-      });
-      importA = main.variable(true).define(["a"], function(a) {
-        return a;
-      });
+      b = main.variable(true).define("b", () => 2);
+      importA = main.variable(true).define(["a"], (a) => a);
       const child1 = runtime.module(define1).derive(["b"], main);
       main.import("a", child1);
       return main;
     }
 
+    // Module 3
+    // c = 3
+    // b
+    // import {b} with {c} from "2"
     function define3() {
       const main = runtime.module();
-      c = main.variable(true).define("c", function() {
-        return 3;
-      });
-      importB = main.variable(true).define(["b"], function(b) {
-        return b;
-      });
+      c = main.variable(true).define("c", () => 3);
+      importB = main.variable(true).define(["b"], (b) => b);
       const child2 = runtime.module(define2).derive(["c"], main);
       main.import("b", child2);
       return main;
@@ -161,8 +162,79 @@ tape(
     test.deepEqual(await valueof(a), {value: 1});
     test.deepEqual(await valueof(b), {value: 2});
     test.deepEqual(await valueof(c), {value: 3});
-    test.deepEqual(await valueof(importA), {error: 'RuntimeError: a is not defined'});
-    test.deepEqual(await valueof(importB), {error: 'RuntimeError: b is not defined'});
-    test.deepEqual(await valueof(importC), {error: 'RuntimeError: c is not defined'});
+    test.deepEqual(await valueof(importA), {value: 1});
+    test.deepEqual(await valueof(importB), {value: 2});
+    test.deepEqual(await valueof(importC), {value: 3});
   }
 );
+
+tape("variable.import() supports lazy imports", async test => {
+  let resolve2, promise2 = new Promise((resolve) => resolve2 = resolve);
+
+  function define1(runtime, observer) {
+    const main = runtime.module();
+    main.define("module 1", async () => runtime.module(await promise2));
+    main.define("a", ["module 1", "@variable"], (_, v) => v.import("a", _));
+    main.variable(observer("imported a")).define("imported a", ["a"], a => a);
+    return main;
+  }
+
+  function define2(runtime, observer) {
+    const main = runtime.module();
+    main.variable(observer("a")).define("a", [], () => 1);
+    return main;
+  }
+
+  const runtime = new Runtime();
+  const inspectorA = promiseInspector();
+  runtime.module(define1, name => {
+    if (name === "imported a") {
+      return inspectorA;
+    }
+  });
+
+  await sleep();
+  resolve2(define2);
+  test.deepEqual(await inspectorA, 1);
+});
+
+tape("variable.import() supports lazy transitive imports", async test => {
+  let resolve2, promise2 = new Promise((resolve) => resolve2 = resolve);
+  let resolve3, promise3 = new Promise((resolve) => resolve3 = resolve);
+
+  function define1(runtime, observer) {
+    const main = runtime.module();
+    main.define("module 1", async () => runtime.module(await promise2));
+    main.define("b", ["module 1", "@variable"], (_, v) => v.import("b", _));
+    main.variable(observer("a")).define("a", ["b"], b => b + 1);
+    return main;
+  }
+
+  function define2(runtime, observer) {
+    const main = runtime.module();
+    main.define("module 1", async () => runtime.module(await promise3));
+    main.define("c", ["module 1", "@variable"], (_, v) => v.import("c", _));
+    main.variable(observer("b")).define("b", ["c"], c => c + 1);
+    return main;
+  }
+
+  function define3(runtime, observer) {
+    const main = runtime.module();
+    main.variable(observer("c")).define("c", [], () => 1);
+    return main;
+  }
+
+  const runtime = new Runtime();
+  const inspectorA = promiseInspector();
+  runtime.module(define1, name => {
+    if (name === "a") {
+      return inspectorA;
+    }
+  });
+
+  await sleep();
+  resolve2(define2);
+  await sleep();
+  resolve3(define3);
+  test.deepEqual(await inspectorA, 3);
+});

--- a/test/variable/valueof.js
+++ b/test/variable/valueof.js
@@ -3,3 +3,22 @@ export default async function valueof(variable) {
   try { return {value: await variable._promise}; }
   catch (error) { return {error: error.toString()}; }
 }
+
+export function promiseInspector() {
+  let fulfilled, rejected;
+  const promise = new Promise((resolve, reject) => {
+    fulfilled = resolve;
+    rejected = reject;
+  });
+  promise.fulfilled = fulfilled;
+  promise.rejected = rejected;
+  return promise;
+}
+
+export function sleep(ms = 50) {
+  return delay(undefined, ms);
+}
+
+export function delay(value, ms) {
+  return new Promise((resolve) => setTimeout(() => resolve(value), ms));
+}


### PR DESCRIPTION
This introduces a new special built-in, `@variable`, allowing a variable to access its Variable instance inside its definition, thereby allowing a variable to redefine itself. The intended purpose of this new built-in is to allow lazy imports (as previously attempted, but now including support for import-with).

The recommended pattern for a lazy import is like so:

```js
function define(runtime, observer) {
  const main = runtime.module();
  main.define("module 1", async () => runtime.module(await import(…)));
  main.define("foo", ["module 1", "@variable"], (_, v) => v.import("foo", _));
  main.variable(observer("bar")).define("bar", () => 42);
  return main;
}
```

And for a lazy import-with:

```js
function define(runtime, observer) {
  const main = runtime.module();
  main.define("module 1", ["@variable"], async (v) => runtime.module(await import(…)).derive([…], v._module)));
  main.define("foo", ["module 1", "@variable"], (_, v) => v.import("foo", _));
  main.variable(observer("bar")).define("bar", () => 42);
  return main;
}
```

The reason `@variable` is needed is for derived modules. For example, consider this alternative (broken) implementation:

```js
function define(runtime, observer) {
  const main = runtime.module();
  main.define("module 1", async () => runtime.module(await import(…)));
  { const v = main.define("foo", ["module 1"], (_) => v.import("foo", _)); } // 🌶 Breaks import-with!
  main.variable(observer("bar")).define("bar", () => 42);
  return main;
}
```

The above code does not work if the module (defined by `define`) is derived using [_module_.derive](https://github.com/observablehq/runtime/blob/main/README.md#module_derive) because the variable `v` captured via closure always refers to the variable in the non-derived (original) module. Whereas when using the `@variable` built-in, the variable can redefine itself even in the context of a derived module. The same logic applies to calling _module_.derive within a variable definition: by using `v._module` instead of `main`, we inject variables from the correct (possibly derived) module.

With lazy imports, we can also allow circular import-with’s, as long as the variable definitions themselves are not circular! Since we no longer need to protect against circular import-with’s, I was able to rewrite _module_.derive to be synchronous rather than asynchronous. I also removed the internal _module_._copy method. Changing _module_.derive isn’t strictly necessary to support lazy imports as the tests work with the old implementation, but I think this new implementation is preferred since it is now synchronous.