### PR TITLE
stdlib 5.6.1

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -126,9 +126,9 @@
     isoformat "^0.2.0"
 
 "@observablehq/stdlib@^5.0.0":
-  version "5.6.0"
-  resolved "https://registry.yarnpkg.com/@observablehq/stdlib/-/stdlib-5.6.0.tgz#2c33f9bdec389e0de2c930b6222800d0d5a7fbd2"
-  integrity sha512-Tli/WUKAbBpPV/hoSwBXOSH2CmtCMQwt1CcjuoXlDMS55/w8ZAvjRjytQ/sbhVlhMJC0ca3eoZeQzcZUdp4oBA==
+  version "5.6.1"
+  resolved "https://registry.yarnpkg.com/@observablehq/stdlib/-/stdlib-5.6.1.tgz#8db8bf1c39a5f2201517f881a6dfef93697a267f"
+  integrity sha512-8+6Ib2zkQNfoLsf4J09ZzNYpUaBnzZXwK39nGZ6W18TvTqB9iDhkbQOPkvJyoZbgeAiIIYnf0FEozJosJZyF8w==
   dependencies:
     d3-array "^3.2.0"
     d3-dsv "^3.0.1"


### PR DESCRIPTION
Depends on https://github.com/observablehq/stdlib/pull/366.