### PR TITLE
5.9.2

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,1 @@
+See checklist for [publishing a new release](https://observablehq.com/@observablehq/publishing-new-open-source-releases).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,1 +1,19 @@
-See checklist for [publishing a new release](https://observablehq.com/@observablehq/publishing-new-open-source-releases).
+The Observable runtime is open source and released under the [ISC License](https://github.com/observablehq/runtime/blob/main/LICENSE). We welcome pull requests. If you have a bug report or feature request, please file an [issue](https://github.com/observablehq/runtime/issues). If you want to discuss or ask for help with using the runtime, post in our [forum](https://talk.observablehq.com/) or [community Slack](https://join.slack.com/t/observable-community/shared_invite/zt-1x7gs4fck-UHhEFxUXKHVE8Qt3XmJCig).
+
+## Development
+
+Install dependencies:
+
+```
+yarn
+```
+
+Run tests with Mocha:
+
+```
+yarn test
+```
+
+## For internal use
+
+See our checklist for [publishing a new release](https://observablehq.com/@observablehq/publishing-new-open-source-releases).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,12 @@ Run tests with Mocha:
 yarn test
 ```
 
+Build with Rollup:
+
+```
+yarn prepublishOnly
+```
+
 ## For internal use
 
 See our checklist for [publishing a new release](https://observablehq.com/@observablehq/publishing-new-open-source-releases).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@observablehq/runtime",
-  "version": "5.9.1",
+  "version": "5.9.2",
   "author": {
     "name": "Observable, Inc.",
     "url": "https://observablehq.com"

--- a/yarn.lock
+++ b/yarn.lock
@@ -126,9 +126,9 @@
     isoformat "^0.2.0"
 
 "@observablehq/stdlib@^5.0.0":
-  version "5.8.1"
-  resolved "https://registry.yarnpkg.com/@observablehq/stdlib/-/stdlib-5.8.1.tgz#50002b0d2a021890052d6f96700d86d15ca18c7d"
-  integrity sha512-ng6QQSzFbPQnMMeCUhUl/EPzpyrwfmGsujztGdPXS1ZYrLoAc9co4rhUC5Vv6dBh8E4yzZkxwNyTs73bLN4alQ==
+  version "5.8.2"
+  resolved "https://registry.yarnpkg.com/@observablehq/stdlib/-/stdlib-5.8.2.tgz#0e5f73064783ed9d23a20feecd4a42bdfb996a30"
+  integrity sha512-68Xo97UJzJNOTDkZFSOqpGifMJ7KCXGXB0EljWIYzu9CzpaAjiakdJgMm2h7xHdPRh8HKoFIEPqeVg7YKjQh0Q==
   dependencies:
     d3-array "^3.2.0"
     d3-dsv "^3.0.1"


### PR DESCRIPTION
- Upgrade stdlib to [v5.8.2](https://github.com/observablehq/stdlib/releases/tag/v5.8.2) to add `pizza` sample dataset.
- Add a (_basic_) CONTRIBUTING.md, with a dual audience in mind of both the community and internal developers.