### PR TITLE
fix stale rejection

### DIFF
--- a/src/runtime.js
+++ b/src/runtime.js
@@ -276,7 +276,7 @@ function variable_compute(variable) {
     variable._value = value;
     variable._fulfilled(value);
   }, (error) => {
-    if (error === variable_stale) return;
+    if (error === variable_stale || variable._version !== version) return;
     variable._value = undefined;
     variable._rejected(error);
   });


### PR DESCRIPTION
Fixes a race condition where a variable can reject after being invalidated. It’d be nice to have a unit test for this, but I’m not sure if it’s practical. I was able to reproduce this (as described in the other private repo).